### PR TITLE
Measurement accuracy, calibration, and human-facing report/compare; shared analyze pipeline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ build/
 
 # Virtual environments
 .venv/
+.hf_cache/
 venv/
 ENV/
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,10 @@ TER bridges both. The core score measures output quality (0-1, where 1 = every t
 
 ## Installation
 
+The Python package lives in the **`TER/`** subdirectory of this repository (where `pyproject.toml` is). From the repo root:
+
 ```bash
+cd TER
 pip install -e .
 ```
 
@@ -71,6 +74,16 @@ ter analyze path/to/session.jsonl --format json
 ter compare session1.jsonl session2.jsonl --sort ter
 ```
 
+### Compare two sessions as before/after (baseline)
+
+When you have exactly **two** session files (e.g. before and after a rules change), a Markdown **delta** table:
+
+```bash
+ter compare before.jsonl after.jsonl --baseline
+```
+
+Uses the same **default** thresholds as a plain `ter analyze` (see [docs/TER_GOAL_AND_CHANGES.md](docs/TER_GOAL_AND_CHANGES.md) for extending this).
+
 ### Discover sessions
 
 ```bash
@@ -79,6 +92,15 @@ ter list ~/.claude/projects/
 ```
 
 Sessions with subagents show the count (e.g. `SESSION_ID (128.5 KB, 6 subagents)`). Subagent files are hidden from the listing.
+
+### Markdown report (human summary)
+
+```bash
+ter report path/to/session.jsonl
+ter report path/to/session.jsonl -o report.md
+```
+
+Prints a **Markdown** one-pager to **stdout**, or writes it to a file with **`-o` / `--output`**. Content includes TER, waste %, cost, **output calibration ratio**, cache, positional TER, top structural patterns, and suggested next steps. Same analysis pipeline and flags as `analyze` (except `--format` / `--group`).
 
 ### Options
 
@@ -98,11 +120,16 @@ ter analyze <path>
 ter compare <paths_or_dirs...>
   --format text|json
   --sort ter|tokens|waste
+  --baseline                 Exactly two .jsonl files: before/after Markdown delta
   Accepts directories (expands to all *.jsonl files inside)
 
 ter list [path]
   --format text|json
   --limit N
+
+ter report <path>
+  -o, --output FILE          Write Markdown to FILE instead of stdout
+  (same threshold/cost flags as analyze)
 ```
 
 ## Try It
@@ -269,7 +296,10 @@ When `--group` is used, TER discovers subagent sessions from the filesystem and 
 
 ```
 src/ter_calculator/
-  cli.py              CLI entry point (analyze, compare, list, --group)
+  cli.py              CLI (analyze, report, compare, list; --group)
+  analyze_pipeline.py Shared full-session analysis (analyze + report)
+  config_parse.py     Cost model & phase-weight parsing
+  session_report.py   Markdown report + baseline delta formatting
   loader.py           JSONL parsing, deduplication, span segmentation, subagent discovery
   intent.py           Intent extraction and embedding
   classifier.py       Span classification (aligned vs waste)
@@ -292,6 +322,22 @@ pytest
 # Lint
 ruff check .
 ```
+
+## Limits of interpretation
+
+TER is a **heuristic** tool, not a tokenizer clone of Anthropic’s API:
+
+- **Spans** use `len(text) // 4` for rough token counts; they will not match billed tokens line-for-line.
+- **Waste classification** uses embeddings and thresholds; it is **not** ground-truth labeling.
+- **Waste \$** uses **assistant-origin** waste and **calibrates** to API `output_tokens` when usage data exists — see `waste_output_calibration_ratio` in JSON. Ratios far from **1.0** mean the heuristic mass diverges from billing; interpret dollars cautiously.
+- **Input-priced vs output-priced** rows in the waste breakdown reflect whether waste behaved like **context re-injection** vs **generated** text (see [UPDATES.md](UPDATES.md)).
+
+For **what changed** and **why** (measurement pass, decoupled tools, `ter report`), read [docs/TER_GOAL_AND_CHANGES.md](docs/TER_GOAL_AND_CHANGES.md).
+
+## Changelog and design notes
+
+Economics calibration, waste \$ pricing, classifier flags, and maintainer notes: [UPDATES.md](UPDATES.md).  
+Evolution toward the project end goal and maintainer proposal: [docs/TER_GOAL_AND_CHANGES.md](docs/TER_GOAL_AND_CHANGES.md).
 
 ## Requirements
 

--- a/UPDATES.md
+++ b/UPDATES.md
@@ -1,0 +1,150 @@
+# TER Calculator — update log and design notes
+
+This document records a focused pass on **measurement accuracy** (especially dollars and input vs output context) and **classifier ergonomics**. It is meant for maintainers and for anyone calibrating the tool against real Claude Code sessions.
+
+---
+
+## What changed (summary)
+
+| Area | Change |
+|------|--------|
+| **Spans** | Each `TokenSpan` now has `source_role` (`assistant` \| `user`), set when segmenting the JSONL. |
+| **Economics** | `estimated_waste_cost_usd` counts **assistant-origin** waste only and **scales** to API `output_tokens` when usage data exists. New field: `waste_output_calibration_ratio`. |
+| **Waste breakdown $** | Rows are tagged **output-priced** vs **input-priced**; totals use the right rate from `CostModel`. JSON includes `pricing` per source. |
+| **Double-counting (breakdown table)** | Pattern rows for `duplicate_tool_call` and `context_restatement` are skipped when the same bucket already appears from classified spans (same idea as `reasoning_loop` ↔ redundant reasoning). See § below. |
+| **Classifier** | `--confidence-threshold` now gates **self-repetition** waste; `--similarity-threshold` shapes filler / verbose thresholds (bounded so defaults stay near legacy behavior). |
+| **Repo hygiene** | `.hf_cache/` added to `.gitignore` for local Hugging Face cache dirs. |
+
+---
+
+## Thought process
+
+### 1. Why `source_role` on spans?
+
+Heuristic span tokens are built from **both** assistant blocks (thinking, text, tool_use) and user blocks (notably **tool_result**). API **`output_tokens`** only reflect what the **assistant** generated. Mixing user-side spans into “output waste $” overstated or misattributed cost, and made calibration meaningless.
+
+**Decision:** Tag spans at load time and use `assistant` vs `user` anywhere we tie waste to **billed output** or to **input-side context cost**.
+
+### 2. Why calibrate waste $ to `output_tokens`?
+
+Span `token_count` uses `len(text) // 4`, which rarely matches Anthropic’s tokenizer. The **ratio** of waste to total is still useful for TER; the **dollar** line should track what you actually pay for generation when usage is present.
+
+**Decision:**  
+`calibration_ratio = billed_output_tokens / sum(assistant span tokens)`  
+`estimated_waste_cost_usd = assistant_waste_tokens × ratio × output_rate / 1e6`
+
+Expose `waste_output_calibration_ratio` so JSON/UI consumers can see when the heuristic is tight or loose (ratios far from 1.0 deserve a glance).
+
+### 3. Why split output vs input pricing in the waste breakdown?
+
+Some detectors measure waste that shows up as **re-injected context** (e.g. repeated Read results, bash stderr/stdout, failed tool results). Pricing that at **output** $/MTok was systematically wrong vs Sonnet-style **input** $/MTok.
+
+**Decision:** Classified assistant waste and most “behavioral” patterns stay **output**-priced; tool-result-heavy patterns use **input**-priced rows. The headline “Waste $” from `_compute_waste_cost` sums both with the appropriate rates and applies output calibration only to output-priced rows.
+
+### 4. Why extend pattern overlap for duplicates / restatement?
+
+If the classifier already counts tokens under “Unnecessary Tool Calls” or “Over-Explanation”, adding the same mass again from **duplicate_tool_call** or **context_restatement** patterns **double-counted** in the breakdown table and inflated “Waste $”.
+
+**Decision:** Mirror the existing `reasoning_loop` ↔ “Redundant Reasoning” overlap for those pattern types when the corresponding category already has tokens from classification.
+
+#### What we fixed in practice (double-counting and related mistakes)
+
+Before this pass, several issues compounded:
+
+1. **Same waste counted twice in the UI/table** — Classifier buckets (e.g. unnecessary tool calls, over-explanation) already attributed tokens to waste. Structural patterns (`duplicate_tool_call`, `context_restatement`) could **add the same phenomenon again** as separate rows. Totals looked worse than the underlying session because **two mechanisms described one failure mode**.
+
+2. **Wrong pricing for some of that mass** — Even after fixing (1), **re-injected context** (tool results, repeated reads) was easy to price like **output**; it is often billed **input**-side. So dollars could be wrong even when token *labels* were right.
+
+3. **“Output waste $” mixed assistant and user-origin spans** — Heuristic spans include **user** `tool_result` text. Billed **`output_tokens`** are **assistant-only**. Mixing roles misattributed cost and broke **calibration** to the API.
+
+The **overlap rules** in `formatter._build_waste_breakdown` address **(1)** directly. **`source_role`**, **input- vs output-priced rows**, and **calibration to `output_tokens`** address **(2)** and **(3)**. Together, the breakdown and headline waste dollar line should **not** inflate the same work twice, and **should** separate invoice-relevant output waste from context-heavy input pricing where the model says so.
+
+### 5. Why wire CLI thresholds into the classifier?
+
+`--similarity-threshold` and `--confidence-threshold` were documented but not fully driving behavior; tuning sessions required changing code.
+
+**Decision:**  
+- **Confidence:** only treat high self-similarity as repetition-waste if `repetition_similarity >= confidence_threshold` (reduces borderline false “duplicate work”).  
+- **Similarity:** map `similarity_threshold` into bounded bands for filler reasoning and long low-intent generation, preserving roughly the old defaults when threshold ≈ 0.40.
+
+---
+
+## How to verify locally
+
+```bash
+cd TER  # project root containing pyproject.toml
+python -m venv .venv && source .venv/bin/activate  # or .venv\Scripts\activate on Windows
+pip install -e ".[dev]"
+
+# Optional: keep HF cache inside the repo (sandbox-friendly)
+export HF_HOME="$(pwd)/.hf_cache"
+
+pytest tests/unit/test_economics.py tests/unit/test_classifier.py tests/unit/test_formatter.py \
+  tests/unit/test_waste.py tests/unit/test_loader.py tests/unit/test_compute.py -q
+
+ter analyze tests/fixtures/sample_session.jsonl --format json
+```
+
+**Note:** Full integration tests and anything that loads `sentence-transformers` need a **writable** Hugging Face cache (or `HF_HOME` pointing inside the repo). Failures from `PermissionError` on `~/.cache/huggingface` are environment-related, not logic errors in the tests themselves.
+
+---
+
+## Before / after (illustrative)
+
+**Scenario:** A few tokens flagged as waste live on a **user** `tool_result` block (edge case in fixtures).
+
+| | Before | After |
+|---|--------|--------|
+| That row in the waste table | Priced at **output** rate | Priced at **input** rate when appropriate |
+| `estimated_waste_cost_usd` | Could mix user + assistant heuristic waste at output $ | **Assistant output waste only**, scaled to **`output_tokens`** when available |
+
+When assistant waste exists and heuristic totals differ from `output_tokens`, **dollar estimates move toward invoice-reality** via `waste_output_calibration_ratio`.
+
+---
+
+## Files touched (reference)
+
+- `src/ter_calculator/models.py` — `TokenSpan.source_role`, `SessionEconomics.waste_output_calibration_ratio`
+- `src/ter_calculator/loader.py` — set `source_role` when building spans
+- `src/ter_calculator/economics.py` — calibration + assistant-only waste cost helpers
+- `src/ter_calculator/classifier.py` — confidence / similarity wiring
+- `src/ter_calculator/formatter.py` — breakdown pricing kinds, overlap rules, JSON fields
+- `src/ter_calculator/analyze_pipeline.py`, `config_parse.py` — shared `analyze` path for CLI consistency
+- `src/ter_calculator/session_report.py`, `cli.py` — `ter report`, `ter compare --baseline`, **`-o`** on report
+- `tests/unit/test_economics.py`, `test_classifier.py`, `test_session_report.py` — extended coverage
+- `.gitignore` — `.hf_cache/`
+
+---
+
+## Future ideas (prioritized)
+
+1. ~~**`ter report`**~~ — **Done (initial):** `ter report <session.jsonl>` emits Markdown; **`-o FILE`** writes `report.md` (or any path) instead of stdout. Optional: grouped run + richer `CLAUDE.md` bullets.
+
+2. **“Lite” mode without embeddings** — Usage + structural detectors only for CI or live hooks; full TER when analyzing offline. Cuts cold-start and flakiness from model download.
+
+3. **Gold set + metrics** — 20–50 hand-labeled spans/snippet pairs; report precision/recall per detector; tune thresholds with data instead of intuition.
+
+4. **Per-phase calibration** — If logs ever expose reasoning vs generation usage separately, split calibration (today only aggregate `output_tokens` exists).
+
+5. **Hooks / live nudge** — Cursor hook every N turns or after estimated $\Delta$: append a short hint file or stderr line (“same file Read 3×”). Pairs with lite mode.
+
+6. **`ter compare --baseline`** — **Done (initial):** two session files → Markdown delta. **Open:** whether to expose full `analyze` flags on compare (today: default thresholds only); TBD.
+
+7. **Export for RL / preferences** — `(turn_index, features, label, cost_proxy)` parquet or JSONL for DPO / offline RL on tool choice (bash vs Read) using existing anti-pattern signal as a reward channel.
+
+8. **Documentation** — Link this file from the main `README.md` in a single sentence when you want discoverability without duplicating content.
+
+---
+
+## Maintenance
+
+When adding a new **waste pattern**:
+
+1. Decide if its `tokens_wasted` is mainly **assistant generation / tool JSON** (output-priced) or **tool results / context** (input-priced) and extend `_pattern_pricing` in `formatter.py` if needed.
+
+2. If the pattern **duplicates** classified categories, add an entry to `pattern_overlap` in `_build_waste_breakdown` so tables and totals stay consistent.
+
+---
+
+
+*Last updated: 2026-04-17*

--- a/docs/TER_GOAL_AND_CHANGES.md
+++ b/docs/TER_GOAL_AND_CHANGES.md
@@ -1,0 +1,74 @@
+# TER: end goal, what changed, and proposal to maintainers
+
+## End goal (unchanged)
+
+**TER Calculator** exists to make **Claude Code sessions** *measurable*: output aligned vs waste, session economics (cost, cache, context growth), input-side signals (redundancy, drift, alignment), and grouped parent/subagent runs — so teams can **change behavior** (prompts, hooks, session length) with numbers that are **as honest as we can make them** given heuristics and API usage fields.
+
+Prompt drafting tools are **out of scope** for this repository; they live separately (see `../prompt-glow/`).
+
+---
+
+## Already documented in `UPDATES.md` (measurement pass)
+
+The table in [UPDATES.md](../UPDATES.md) describes a focused pass on:
+
+- **`source_role` on spans** — align “waste \$” with **assistant** generation vs **user/context** (e.g. tool results).
+- **Calibration** of waste dollars to **`output_tokens`** when present — `waste_output_calibration_ratio` exposes mismatch.
+- **Output- vs input-priced** waste rows — stop pricing re-injected context at output \$/MTok.
+- **Overlap rules** — avoid double-counting classifier vs pattern buckets.
+- **CLI thresholds** — `--confidence-threshold` / `--similarity-threshold` actually drive the classifier.
+
+**Why it matters:** Without this, headline metrics could be **directionally useful** but **wrong on money and attribution** — which undermines trust and any “we saved \$X” narrative.
+
+---
+
+## Changes in this evolution (repository layout + product)
+
+### 1. `ter report` — human-facing summary
+
+- **What:** `ter report <session.jsonl>` runs the **same pipeline** as `analyze` and prints **Markdown** (or writes it with **`-o FILE`**, e.g. `report.md`): headline TER, waste %, cost, **calibration ratio**, cache, positional TER, top structural patterns, **action bullets**.
+- **Why:** Closes the loop from “JSON for scripts” to **action** (UPDATES “future idea #1” — implemented in minimal form).
+- **End goal:** Faster **human-in-the-loop** improvement without reading full Rich/JSON output.
+
+### 2. `ter compare --baseline`
+
+- **What:** Exactly **two** session files → Markdown **delta table** (TER, waste ratio, cost) + short interpretation note.
+- **Why:** Supports **before/after** narratives (rules change, prompt template change). Uses **default analyze thresholds** unless we later extend the CLI (documented).
+- **End goal:** Comparable **A/B** storytelling for process changes.
+
+### 3. Shared pipeline — `analyze_pipeline.py` + `config_parse.py`
+
+- **What:** Single `analyze_session(args)` used by `analyze` and `report`; cost/phase parsing centralized.
+- **Why:** Less drift between commands; easier testing.
+- **End goal:** **Consistency** of measurement across entry points.
+
+### 4. Trust layer — README “Limits of interpretation”
+
+- **What:** Explicit limits: heuristic spans, `len(text)//4`, calibration meaning, TER ≠ ground truth labels.
+- **Why:** Stops over-claiming; aligns user expectations with epistemics (per prior review).
+- **End goal:** **Credible** use in serious retros, not only demos.
+
+---
+
+## Not done yet (recommended next)
+
+| Item | Rationale |
+|------|-----------|
+| **Gold set + precision/recall** | Thresholds are still intuition-led. |
+| **Lite mode (no embeddings)** | CI / hooks; cold-start (UPDATES #2). |
+| **Wire analyze flags into `--baseline`** | Today baseline uses `default_analyze_args()` only. |
+| **`ter report` from grouped runs** | Parent + subagents as one Markdown report. |
+
+---
+
+## Maintainer decisions (recorded)
+
+| Topic | Decision |
+|--------|----------|
+| **Versioning** | **No semver bump required** for this work alone; ship on a **branch** as needed (no obligation to jump to `0.2.0`). |
+| **`ter report` output** | **`-o` / `--output FILE`** supported (e.g. `report.md`); default remains stdout. |
+| **`ter compare --baseline` flags** | **Undecided** — compare currently uses **default analyze thresholds** only; wiring full `analyze` flags is optional follow-up. |
+
+---
+
+*This file is the “proposal + changelog” requested to align maintainers on scope and direction.*

--- a/src/ter_calculator/analyze_pipeline.py
+++ b/src/ter_calculator/analyze_pipeline.py
@@ -1,0 +1,76 @@
+"""Shared single-session analysis pipeline (analyze / report)."""
+
+from __future__ import annotations
+
+import argparse
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .models import TERResult
+
+
+def default_analyze_args(session_path: str) -> argparse.Namespace:
+    """Defaults for `ter compare --baseline` when analyze flags are not on the CLI."""
+    return argparse.Namespace(
+        session_path=session_path,
+        similarity_threshold=0.40,
+        confidence_threshold=0.75,
+        restatement_threshold=0.85,
+        phase_weights="0.3,0.4,0.3",
+        no_waste_patterns=False,
+        cost_model="sonnet",
+        no_input_analysis=False,
+        prompt_similarity_threshold=0.75,
+    )
+
+
+def analyze_session(args) -> "TERResult":
+    """Run full TER pipeline for one JSONL session. `args` matches analyze subcommand."""
+    from .config_parse import parse_cost_model, parse_phase_weights
+    from .loader import load_session, segment_spans
+    from .intent import extract_intent
+    from .classifier import classify_spans
+    from .compute import compute_ter
+    from .economics import compute_economics
+
+    phase_weights = parse_phase_weights(args.phase_weights)
+
+    session = load_session(args.session_path)
+    spans = segment_spans(session)
+    intent = extract_intent(session)
+
+    classified = classify_spans(
+        spans,
+        intent,
+        similarity_threshold=args.similarity_threshold,
+        confidence_threshold=args.confidence_threshold,
+    )
+
+    result = compute_ter(
+        classified,
+        session_id=session.session_id,
+        intent=intent,
+        phase_weights=phase_weights,
+    )
+
+    if not args.no_waste_patterns:
+        from .waste import detect_waste_patterns
+
+        result.waste_patterns = detect_waste_patterns(
+            classified,
+            restatement_threshold=args.restatement_threshold,
+            session=session,
+        )
+
+    cost_model = parse_cost_model(args.cost_model)
+    result.economics = compute_economics(session, classified, cost_model)
+
+    if not args.no_input_analysis:
+        from .input_analysis import analyze_input
+
+        result.input_analysis = analyze_input(
+            session,
+            similarity_threshold=args.prompt_similarity_threshold,
+        )
+
+    return result

--- a/src/ter_calculator/classifier.py
+++ b/src/ter_calculator/classifier.py
@@ -85,6 +85,7 @@ def classify_spans(
             is_repetition=is_repetition,
             repetition_similarity=rep_sim,
             similarity_threshold=similarity_threshold,
+            confidence_threshold=confidence_threshold,
             span_text=span.text,
         )
 
@@ -133,6 +134,7 @@ def _classify_span(
     is_repetition: bool,
     repetition_similarity: float,
     similarity_threshold: float,
+    confidence_threshold: float,
     span_text: str,
 ) -> tuple[SpanLabel, float]:
     """Classify a single span using multiple signals.
@@ -141,6 +143,14 @@ def _classify_span(
     """
     # Signal 1: Self-repetition (strongest waste signal).
     if is_repetition:
+        # Require strong agreement with a prior span; avoids borderline
+        # embeddings being scored as duplicate work.
+        if repetition_similarity < confidence_threshold:
+            if phase == SpanPhase.REASONING:
+                return SpanLabel.ALIGNED_REASONING, max(0.5, sim)
+            if phase == SpanPhase.TOOL_USE:
+                return SpanLabel.ALIGNED_TOOL_CALL, max(0.6, sim)
+            return SpanLabel.ALIGNED_RESPONSE, max(0.5, sim)
         confidence = repetition_similarity
         if phase == SpanPhase.REASONING:
             return SpanLabel.REDUNDANT_REASONING, confidence
@@ -151,9 +161,13 @@ def _classify_span(
     # Signal 2: Very low intent similarity + phase-specific checks.
     # Only for reasoning and generation — tool calls are actions,
     # not words, so low semantic similarity is expected and normal.
+    # Bounds keep defaults close to legacy 0.10 / 0.08 when threshold≈0.40.
+    filler_sim_max = max(0.06, min(0.14, similarity_threshold * 0.28))
+    verbose_sim_max = max(0.05, min(0.12, similarity_threshold * 0.22))
+
     if phase == SpanPhase.REASONING:
         # Reasoning with very low relevance AND short text (filler).
-        if sim < 0.10 and len(span_text.split()) < 15:
+        if sim < filler_sim_max and len(span_text.split()) < 15:
             return SpanLabel.REDUNDANT_REASONING, 0.5
         return SpanLabel.ALIGNED_REASONING, max(0.5, sim)
 
@@ -165,7 +179,7 @@ def _classify_span(
     if phase == SpanPhase.GENERATION:
         # Generation with extremely low relevance is suspicious,
         # but only if it's also substantial (short responses are fine).
-        if sim < 0.08 and len(span_text.split()) > 50:
+        if sim < verbose_sim_max and len(span_text.split()) > 50:
             return SpanLabel.OVER_EXPLANATION, 0.4
         return SpanLabel.ALIGNED_RESPONSE, max(0.5, sim)
 

--- a/src/ter_calculator/cli.py
+++ b/src/ter_calculator/cli.py
@@ -5,9 +5,9 @@ from __future__ import annotations
 import argparse
 import io
 import sys
+from pathlib import Path
 
 from . import __version__
-from .models import SpanPhase
 
 
 def _setup_stdout_encoding():
@@ -83,6 +83,55 @@ def main(argv: list[str] | None = None) -> int:
         help="Include subagent sessions in grouped analysis"
     )
 
+    # report — Markdown summary (same analysis pipeline as analyze)
+    report_parser = subparsers.add_parser(
+        "report",
+        help="Print a Markdown summary (headline metrics, calibration, top waste, next steps)",
+    )
+    report_parser.add_argument(
+        "session_path", help="Path to a JSONL session file"
+    )
+    report_parser.add_argument(
+        "--similarity-threshold", type=float, default=0.40,
+        help="Cosine similarity threshold for alignment (default: 0.40)"
+    )
+    report_parser.add_argument(
+        "--confidence-threshold", type=float, default=0.75,
+        help="Classifier confidence threshold (default: 0.75)"
+    )
+    report_parser.add_argument(
+        "--restatement-threshold", type=float, default=0.85,
+        help="Similarity threshold for context restatement (default: 0.85)"
+    )
+    report_parser.add_argument(
+        "--phase-weights", type=str, default="0.3,0.4,0.3",
+        help="Phase weights as r,t,g (default: 0.3,0.4,0.3)"
+    )
+    report_parser.add_argument(
+        "--no-waste-patterns", action="store_true",
+        help="Disable waste pattern detection"
+    )
+    report_parser.add_argument(
+        "--cost-model", type=str, default="sonnet",
+        help="Cost model: 'sonnet' (default) or custom rates per MTok"
+    )
+    report_parser.add_argument(
+        "--no-input-analysis", action="store_true",
+        help="Disable input analysis"
+    )
+    report_parser.add_argument(
+        "--prompt-similarity-threshold", type=float, default=0.75,
+        help="Cosine similarity threshold for redundant prompts (default: 0.75)"
+    )
+    report_parser.add_argument(
+        "-o",
+        "--output",
+        dest="report_output",
+        metavar="FILE",
+        default=None,
+        help="Write Markdown to FILE instead of stdout (e.g. report.md)",
+    )
+
     # compare subcommand
     compare_parser = subparsers.add_parser(
         "compare", help="Compare TER across multiple sessions"
@@ -97,6 +146,10 @@ def main(argv: list[str] | None = None) -> int:
     compare_parser.add_argument(
         "--sort", choices=["ter", "tokens", "waste"],
         default="ter", help="Sort order (default: ter)"
+    )
+    compare_parser.add_argument(
+        "--baseline", action="store_true",
+        help="Compare exactly two sessions as before/after (Markdown delta; uses default analyze thresholds)",
     )
 
     # list subcommand
@@ -131,6 +184,8 @@ def main(argv: list[str] | None = None) -> int:
             return _cmd_compare(args)
         if args.command == "list":
             return _cmd_list(args)
+        if args.command == "report":
+            return _cmd_report(args)
     except FileNotFoundError as e:
         print(f"Error: {e}", file=sys.stderr)
         return 1
@@ -152,51 +207,28 @@ def _cmd_analyze(args) -> int:
     if args.group:
         return _cmd_analyze_group(args)
 
-    from .loader import load_session, segment_spans
-    from .intent import extract_intent
-    from .classifier import classify_spans
-    from .compute import compute_ter
+    from .analyze_pipeline import analyze_session
     from .formatter import format_ter_result
 
-    phase_weights = _parse_phase_weights(args.phase_weights)
-
-    session = load_session(args.session_path)
-    spans = segment_spans(session)
-    intent = extract_intent(session)
-
-    classified = classify_spans(
-        spans, intent,
-        similarity_threshold=args.similarity_threshold,
-        confidence_threshold=args.confidence_threshold,
-    )
-
-    result = compute_ter(
-        classified,
-        session_id=session.session_id,
-        intent=intent,
-        phase_weights=phase_weights,
-    )
-
-    if not args.no_waste_patterns:
-        from .waste import detect_waste_patterns
-        result.waste_patterns = detect_waste_patterns(
-            classified,
-            restatement_threshold=args.restatement_threshold,
-            session=session,
-        )
-
-    from .economics import compute_economics
-    cost_model = _parse_cost_model(args.cost_model)
-    result.economics = compute_economics(session, classified, cost_model)
-
-    if not args.no_input_analysis:
-        from .input_analysis import analyze_input
-        result.input_analysis = analyze_input(
-            session,
-            similarity_threshold=args.prompt_similarity_threshold,
-        )
-
+    result = analyze_session(args)
     print(format_ter_result(result, fmt=args.output_format))
+    return 0
+
+
+def _cmd_report(args) -> int:
+    """Markdown one-screen summary for humans."""
+    from .analyze_pipeline import analyze_session
+    from .session_report import format_session_report_markdown
+
+    result = analyze_session(args)
+    md = format_session_report_markdown(result)
+    out = getattr(args, "report_output", None)
+    if out:
+        Path(out).write_text(md, encoding="utf-8")
+        if not args.quiet:
+            print(f"Wrote {out}", file=sys.stderr)
+    else:
+        print(md)
     return 0
 
 
@@ -218,8 +250,10 @@ def _cmd_analyze_group(args) -> int:
         args.group = False
         return _cmd_analyze(args)
 
-    phase_weights = _parse_phase_weights(args.phase_weights)
-    cost_model = _parse_cost_model(args.cost_model)
+    from .config_parse import parse_cost_model, parse_phase_weights
+
+    phase_weights = parse_phase_weights(args.phase_weights)
+    cost_model = parse_cost_model(args.cost_model)
 
     def _analyze_session(path):
         session = load_session(path)
@@ -263,14 +297,9 @@ def _cmd_analyze_group(args) -> int:
 
 def _cmd_compare(args) -> int:
     """Execute the compare subcommand."""
-    from .loader import load_session, segment_spans
-    from .intent import extract_intent
-    from .classifier import classify_spans
-    from .compute import compute_ter
-    from .formatter import format_comparison
-
     from pathlib import Path
-    from .economics import compute_economics
+
+    from .formatter import format_comparison
 
     # Expand directory paths to all .jsonl files inside them.
     paths = []
@@ -285,6 +314,33 @@ def _cmd_compare(args) -> int:
         print("No .jsonl files found.", file=sys.stderr)
         return 1
 
+    if getattr(args, "baseline", False):
+        if len(paths) != 2:
+            print(
+                "Error: --baseline requires exactly two session files.",
+                file=sys.stderr,
+            )
+            return 1
+        for p in paths:
+            if Path(p).is_dir():
+                print(
+                    "Error: --baseline requires file paths, not directories.",
+                    file=sys.stderr,
+                )
+                return 1
+        from .analyze_pipeline import analyze_session, default_analyze_args
+        from .session_report import format_baseline_markdown
+
+        ra = analyze_session(default_analyze_args(paths[0]))
+        rb = analyze_session(default_analyze_args(paths[1]))
+        print(format_baseline_markdown(ra, rb))
+        return 0
+
+    from .loader import load_session, segment_spans
+    from .intent import extract_intent
+    from .classifier import classify_spans
+    from .compute import compute_ter
+    from .economics import compute_economics
     from .waste import detect_waste_patterns
 
     results = []
@@ -361,52 +417,6 @@ def _cmd_list(args) -> int:
                 print(f"     {s['path']}")
 
     return 0
-
-
-def _parse_cost_model(value: str):
-    """Parse cost model argument."""
-    from .models import CostModel
-    if value.lower() == "sonnet":
-        return CostModel()
-    parts = value.split(",")
-    if len(parts) != 4:
-        raise ValueError(
-            f"Cost model must be 'sonnet' or 4 comma-separated rates, got: {value}"
-        )
-    try:
-        return CostModel(
-            input_rate=float(parts[0]),
-            output_rate=float(parts[1]),
-            cache_read_rate=float(parts[2]),
-            cache_write_rate=float(parts[3]),
-        )
-    except ValueError:
-        raise ValueError(f"Invalid cost model rates: {value}")
-
-
-def _parse_phase_weights(weights_str: str) -> dict[SpanPhase, float]:
-    """Parse comma-separated phase weights."""
-    parts = weights_str.split(",")
-    if len(parts) != 3:
-        raise ValueError(
-            f"Phase weights must be 3 comma-separated values, got: {weights_str}"
-        )
-    try:
-        r, t, g = float(parts[0]), float(parts[1]), float(parts[2])
-    except ValueError:
-        raise ValueError(f"Invalid phase weight values: {weights_str}")
-
-    total = r + t + g
-    if abs(total - 1.0) > 0.01:
-        raise ValueError(
-            f"Phase weights must sum to 1.0, got {total}: {weights_str}"
-        )
-
-    return {
-        SpanPhase.REASONING: r,
-        SpanPhase.TOOL_USE: t,
-        SpanPhase.GENERATION: g,
-    }
 
 
 if __name__ == "__main__":

--- a/src/ter_calculator/config_parse.py
+++ b/src/ter_calculator/config_parse.py
@@ -1,0 +1,50 @@
+"""Parse CLI cost model and phase-weight strings (shared by analyze/report)."""
+
+from __future__ import annotations
+
+from .models import CostModel, SpanPhase
+
+
+def parse_cost_model(value: str) -> CostModel:
+    """Parse cost model argument."""
+    if value.lower() == "sonnet":
+        return CostModel()
+    parts = value.split(",")
+    if len(parts) != 4:
+        raise ValueError(
+            f"Cost model must be 'sonnet' or 4 comma-separated rates, got: {value}"
+        )
+    try:
+        return CostModel(
+            input_rate=float(parts[0]),
+            output_rate=float(parts[1]),
+            cache_read_rate=float(parts[2]),
+            cache_write_rate=float(parts[3]),
+        )
+    except ValueError:
+        raise ValueError(f"Invalid cost model rates: {value}")
+
+
+def parse_phase_weights(weights_str: str) -> dict[SpanPhase, float]:
+    """Parse comma-separated phase weights."""
+    parts = weights_str.split(",")
+    if len(parts) != 3:
+        raise ValueError(
+            f"Phase weights must be 3 comma-separated values, got: {weights_str}"
+        )
+    try:
+        r, t, g = float(parts[0]), float(parts[1]), float(parts[2])
+    except ValueError:
+        raise ValueError(f"Invalid phase weight values: {weights_str}")
+
+    total = r + t + g
+    if abs(total - 1.0) > 0.01:
+        raise ValueError(
+            f"Phase weights must sum to 1.0, got {total}: {weights_str}"
+        )
+
+    return {
+        SpanPhase.REASONING: r,
+        SpanPhase.TOOL_USE: t,
+        SpanPhase.GENERATION: g,
+    }

--- a/src/ter_calculator/economics.py
+++ b/src/ter_calculator/economics.py
@@ -26,7 +26,9 @@ def compute_economics(
     cache_hit = _compute_cache_hit_rate(cache_read, input_tok)
     io_ratio = input_tok / output_tok if output_tok > 0 else 0.0
     cost = _estimate_cost(input_tok, output_tok, cache_read, cache_create, model)
-    waste_cost = _estimate_waste_cost(classified_spans, model)
+    waste_cost, cal_ratio = _estimate_waste_cost(
+        classified_spans, model, billed_output_tokens=output_tok,
+    )
     positional = _compute_positional_breakdown(classified_spans)
     growth = _compute_input_growth(session)
 
@@ -42,6 +44,7 @@ def compute_economics(
         cost_model=model,
         positional=positional,
         input_growth=growth,
+        waste_output_calibration_ratio=round(cal_ratio, 4),
     )
 
 
@@ -91,16 +94,42 @@ def _estimate_cost(
     )
 
 
+def _assistant_span_token_total(classified_spans: list[ClassifiedSpan]) -> int:
+    """Heuristic token count for assistant-origin spans (matches billed output scope)."""
+    return sum(
+        cs.span.token_count for cs in classified_spans
+        if cs.span.source_role == "assistant"
+    )
+
+
+def _assistant_waste_tokens(classified_spans: list[ClassifiedSpan]) -> int:
+    """Waste tokens attributed to assistant messages only."""
+    return sum(
+        cs.span.token_count for cs in classified_spans
+        if cs.label not in ALIGNED_LABELS and cs.span.source_role == "assistant"
+    )
+
+
 def _estimate_waste_cost(
     classified_spans: list[ClassifiedSpan],
     cost_model: CostModel,
-) -> float:
-    """Estimate the dollar cost of waste output tokens."""
-    waste_tokens = sum(
-        cs.span.token_count for cs in classified_spans
-        if cs.label not in ALIGNED_LABELS
-    )
-    return waste_tokens * cost_model.output_rate / 1_000_000
+    billed_output_tokens: int = 0,
+) -> tuple[float, float]:
+    """Estimate USD cost of classified output waste and a calibration ratio.
+
+    Span ``token_count`` uses a char/4 heuristic and can diverge from API
+    ``output_tokens``. Scale waste $ so it tracks billed generation when usage
+    data is present.
+
+    Returns (cost_usd, calibration_ratio).
+    """
+    waste_tokens = _assistant_waste_tokens(classified_spans)
+    assistant_total = _assistant_span_token_total(classified_spans)
+    ratio = 1.0
+    if billed_output_tokens > 0 and assistant_total > 0:
+        ratio = billed_output_tokens / assistant_total
+    cost = waste_tokens * ratio * cost_model.output_rate / 1_000_000
+    return cost, ratio
 
 
 def _compute_positional_breakdown(

--- a/src/ter_calculator/formatter.py
+++ b/src/ter_calculator/formatter.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 import io
 
-from .models import InputAnalysis, TERResult, WastePattern
+from .models import CostModel, InputAnalysis, TERResult, WastePattern
 from .waste import summarize_waste
 
 
@@ -241,28 +241,51 @@ def _format_rich(result: TERResult) -> str:
 
 
 def _compute_waste_cost(result: TERResult) -> float:
-    """Compute total waste cost from the waste breakdown (all sources)."""
+    """Compute total waste $ from breakdown rows (mixed input/output pricing)."""
     rows = _build_waste_breakdown(result)
     if not rows:
         return 0.0
-    cost_rate = 15.0
-    if result.economics:
-        cost_rate = result.economics.cost_model.output_rate
-    total_tokens = sum(t for _, t, _ in rows)
-    return total_tokens * cost_rate / 1_000_000
+    cm = result.economics.cost_model if result.economics else CostModel()
+    scale = (
+        result.economics.waste_output_calibration_ratio
+        if result.economics else 1.0
+    )
+    total = 0.0
+    for _label, tokens, _count, kind in rows:
+        rate = cm.output_rate if kind == "output" else cm.input_rate
+        eff = float(tokens) * (scale if kind == "output" else 1.0)
+        total += eff * rate / 1_000_000
+    return total
 
 
-def _build_waste_breakdown(result: TERResult) -> list[tuple[str, int, int]]:
-    """Build waste breakdown rows: (label, tokens, instance_count).
+def _pattern_pricing(pattern_type: str) -> str:
+    """Structural patterns whose token cost is mostly input-side context."""
+    if pattern_type in (
+        "repetitive_read",
+        "bash_antipattern",
+        "failed_tool_retry",
+        "repeated_command",
+    ):
+        return "input"
+    return "output"
 
-    Combines classified span waste (by label) with structural pattern
-    waste (repetitive reads, edit fragmentation) without double-counting.
+
+def _build_waste_breakdown(
+    result: TERResult,
+) -> list[tuple[str, int, int, str]]:
+    """Build rows: (label, tokens, instance_count, pricing_kind).
+
+    ``pricing_kind`` is ``output`` (billed as generation / assistant tool
+    JSON) or ``input`` (tool results re-sent as context). Output-priced
+    rows are scaled elsewhere to match API ``output_tokens`` when known.
+
+    Skips pattern rows that duplicate classified span categories.
     """
     from .models import ALIGNED_LABELS
 
-    rows: list[tuple[str, int, int]] = []
+    rows: list[tuple[str, int, int, str]] = []
 
-    # Classified output waste by category.
+    # Classified waste: assistant spans priced as output; rare user spans as input.
     category_map = {
         "redundant_reasoning": "Redundant Reasoning",
         "unnecessary_tool_call": "Unnecessary Tool Calls",
@@ -270,8 +293,14 @@ def _build_waste_breakdown(result: TERResult) -> list[tuple[str, int, int]]:
     }
     cat_tokens: dict[str, int] = {}
     cat_counts: dict[str, int] = {}
+    user_waste_tokens = 0
+    user_waste_count = 0
     for cs in result.classified_spans:
         if cs.label in ALIGNED_LABELS:
+            continue
+        if cs.span.source_role != "assistant":
+            user_waste_tokens += cs.span.token_count
+            user_waste_count += 1
             continue
         label = cs.label.value
         cat = category_map.get(label, label.replace("_", " ").title())
@@ -280,10 +309,16 @@ def _build_waste_breakdown(result: TERResult) -> list[tuple[str, int, int]]:
 
     for cat in category_map.values():
         if cat in cat_tokens:
-            rows.append((cat, cat_tokens[cat], cat_counts[cat]))
+            rows.append((cat, cat_tokens[cat], cat_counts[cat], "output"))
 
-    # Waste patterns grouped by type.
-    # Skip types whose waste is already counted from classified spans.
+    if user_waste_tokens > 0:
+        rows.append((
+            "User-side context (waste)",
+            user_waste_tokens,
+            max(1, user_waste_count),
+            "input",
+        ))
+
     pattern_labels = {
         "reasoning_loop": "Reasoning Loops",
         "duplicate_tool_call": "Duplicate Tool Calls",
@@ -294,9 +329,10 @@ def _build_waste_breakdown(result: TERResult) -> list[tuple[str, int, int]]:
         "failed_tool_retry": "Failed Tool Retries",
         "repeated_command": "Repeated Commands",
     }
-    # Map pattern types to the classified span category they overlap with.
     pattern_overlap = {
         "reasoning_loop": "Redundant Reasoning",
+        "duplicate_tool_call": "Unnecessary Tool Calls",
+        "context_restatement": "Over-Explanation",
     }
     by_type: dict[str, list[WastePattern]] = {}
     for wp in (result.waste_patterns or []):
@@ -305,10 +341,11 @@ def _build_waste_breakdown(result: TERResult) -> list[tuple[str, int, int]]:
     for ptype, wps in by_type.items():
         overlap_cat = pattern_overlap.get(ptype)
         if overlap_cat and overlap_cat in cat_tokens:
-            continue  # Already counted from classified spans
+            continue
         label = pattern_labels.get(ptype, ptype.replace("_", " ").title())
         tokens = sum(wp.tokens_wasted for wp in wps)
-        rows.append((label, tokens, len(wps)))
+        kind = _pattern_pricing(ptype)
+        rows.append((label, tokens, len(wps), kind))
 
     rows.sort(key=lambda r: r[1], reverse=True)
     return rows
@@ -322,11 +359,12 @@ def _format_waste_breakdown_rich(console, result: TERResult) -> None:
     if not rows:
         return
 
-    cost_rate = 15.0  # default output rate $/MTok
-    if result.economics:
-        cost_rate = result.economics.cost_model.output_rate
-
-    total_waste = sum(t for _, t, _ in rows)
+    total_waste = sum(t for _, t, _, _ in rows)
+    scale = (
+        result.economics.waste_output_calibration_ratio
+        if result.economics else 1.0
+    )
+    cm = result.economics.cost_model if result.economics else CostModel()
 
     table = Table(show_header=True, show_edge=True, title="Waste Breakdown")
     table.add_column("Source", style="bold", width=22)
@@ -335,19 +373,21 @@ def _format_waste_breakdown_rich(console, result: TERResult) -> None:
     table.add_column("Cost", justify="right", width=8)
     table.add_column("Count", justify="right", width=6, style="dim")
 
-    for label, tokens, count in rows:
+    for label, tokens, count, kind in rows:
         pct = (tokens / total_waste * 100) if total_waste > 0 else 0
-        cost = tokens * cost_rate / 1_000_000
+        rate = cm.output_rate if kind == "output" else cm.input_rate
+        eff = float(tokens) * (scale if kind == "output" else 1.0)
+        row_cost = eff * rate / 1_000_000
         table.add_row(
             label,
             f"{tokens:,}",
             f"{pct:.0f}%",
-            f"${cost:.4f}",
+            f"${row_cost:.4f}",
             str(count),
         )
 
     table.add_section()
-    total_cost = total_waste * cost_rate / 1_000_000
+    total_cost = _compute_waste_cost(result)
     table.add_row(
         "[bold]Total[/bold]",
         f"[bold]{total_waste:,}[/bold]",
@@ -746,17 +786,23 @@ def _format_text(result: TERResult) -> str:
     # Waste breakdown.
     rows = _build_waste_breakdown(result)
     if rows:
-        cost_rate = 15.0
-        if result.economics:
-            cost_rate = result.economics.cost_model.output_rate
-        total_waste = sum(t for _, t, _ in rows)
+        total_waste = sum(t for _, t, _, _ in rows)
+        scale = (
+            result.economics.waste_output_calibration_ratio
+            if result.economics else 1.0
+        )
+        cm = result.economics.cost_model if result.economics else CostModel()
         lines.extend(["", "Waste Breakdown:"])
         lines.append(f"  {'Source':<24} {'Tokens':>10} {'%':>5} {'Cost':>10} {'Count':>6}")
-        for label, tokens, count in rows:
+        for label, tokens, count, kind in rows:
             pct = (tokens / total_waste * 100) if total_waste > 0 else 0
-            cost = tokens * cost_rate / 1_000_000
-            lines.append(f"  {label:<24} {tokens:>10,} {pct:>4.0f}% ${cost:>8.4f} {count:>6}")
-        total_cost = total_waste * cost_rate / 1_000_000
+            rate = cm.output_rate if kind == "output" else cm.input_rate
+            eff = float(tokens) * (scale if kind == "output" else 1.0)
+            row_cost = eff * rate / 1_000_000
+            lines.append(
+                f"  {label:<24} {tokens:>10,} {pct:>4.0f}% ${row_cost:>8.4f} {count:>6}"
+            )
+        total_cost = _compute_waste_cost(result)
         lines.append(f"  {'Total':<24} {total_waste:>10,}  100% ${total_cost:>8.4f}")
 
     # Input analysis.
@@ -897,23 +943,29 @@ def _ter_result_to_dict(result: TERResult) -> dict:
         }
     rows = _build_waste_breakdown(result)
     if rows:
-        cost_rate = 15.0
-        if result.economics:
-            cost_rate = result.economics.cost_model.output_rate
-        total_waste = sum(t for _, t, _ in rows)
+        total_waste = sum(t for _, t, _, _ in rows)
+        scale = (
+            result.economics.waste_output_calibration_ratio
+            if result.economics else 1.0
+        )
+        cm = result.economics.cost_model if result.economics else CostModel()
+        sources = []
+        for label, tokens, count, kind in rows:
+            rate = cm.output_rate if kind == "output" else cm.input_rate
+            eff = float(tokens) * (scale if kind == "output" else 1.0)
+            row_cost = eff * rate / 1_000_000
+            sources.append({
+                "source": label,
+                "tokens": tokens,
+                "percentage": round(tokens / total_waste * 100, 1) if total_waste > 0 else 0,
+                "cost_usd": round(row_cost, 6),
+                "count": count,
+                "pricing": kind,
+            })
         data["waste_breakdown"] = {
-            "sources": [
-                {
-                    "source": label,
-                    "tokens": tokens,
-                    "percentage": round(tokens / total_waste * 100, 1) if total_waste > 0 else 0,
-                    "cost_usd": round(tokens * cost_rate / 1_000_000, 6),
-                    "count": count,
-                }
-                for label, tokens, count in rows
-            ],
+            "sources": sources,
             "total_tokens": total_waste,
-            "total_cost_usd": round(total_waste * cost_rate / 1_000_000, 6),
+            "total_cost_usd": round(_compute_waste_cost(result), 6),
         }
     if result.economics is not None:
         econ = result.economics
@@ -926,6 +978,7 @@ def _ter_result_to_dict(result: TERResult) -> dict:
             "cache_hit_rate": econ.cache_hit_rate,
             "estimated_cost_usd": econ.estimated_cost_usd,
             "estimated_waste_cost_usd": econ.estimated_waste_cost_usd,
+            "waste_output_calibration_ratio": econ.waste_output_calibration_ratio,
             "cost_model": {
                 "input_rate": econ.cost_model.input_rate,
                 "output_rate": econ.cost_model.output_rate,

--- a/src/ter_calculator/loader.py
+++ b/src/ter_calculator/loader.py
@@ -128,6 +128,7 @@ def segment_spans(session: Session) -> list[TokenSpan]:
                 token_count=token_count,
                 source_message_uuid=message.uuid,
                 block_type=block.block_type,
+                source_role=message.role,
             ))
             position += 1
 

--- a/src/ter_calculator/models.py
+++ b/src/ter_calculator/models.py
@@ -90,6 +90,8 @@ class TokenSpan:
     source_message_uuid: str
     block_type: str = ""  # e.g. "tool_use", "tool_result", "text", "thinking"
     embedding: np.ndarray | None = None
+    # assistant | user — aligns waste $ with billed output vs input context.
+    source_role: str = "assistant"
 
 
 @dataclass
@@ -162,6 +164,8 @@ class SessionEconomics:
     cost_model: CostModel
     positional: PositionalBreakdown
     input_growth: InputGrowth
+    """Billed output_tokens / heuristic assistant span tokens (1.0 if N/A)."""
+    waste_output_calibration_ratio: float = 1.0
 
 
 @dataclass

--- a/src/ter_calculator/session_report.py
+++ b/src/ter_calculator/session_report.py
@@ -1,0 +1,136 @@
+"""Human-readable Markdown reports for TER (closes the loop from JSON to action)."""
+
+from __future__ import annotations
+
+from .formatter import _compute_waste_cost
+from .models import TERResult
+
+
+def format_session_report_markdown(result: TERResult) -> str:
+    """One-screen Markdown summary: headline metrics, calibration, top waste, next steps."""
+    lines: list[str] = []
+    sid = result.session_id
+    lines.append(f"# TER report: `{sid}`")
+    lines.append("")
+
+    waste_pct = (
+        (result.waste_tokens / result.total_tokens * 100) if result.total_tokens else 0.0
+    )
+    lines.append("## Summary")
+    lines.append("")
+    lines.append("| Metric | Value |")
+    lines.append("|--------|-------|")
+    lines.append(f"| **TER** | {result.aggregate_ter:.3f} |")
+    lines.append(f"| **Waste** | {result.waste_tokens:,} / {result.total_tokens:,} tokens ({waste_pct:.1f}%) |")
+    if result.economics:
+        e = result.economics
+        lines.append(f"| **Est. session cost** | ${e.estimated_cost_usd:.4f} |")
+        wc = _compute_waste_cost(result)
+        lines.append(f"| **Waste $ (breakdown)** | ${wc:.4f} |")
+        lines.append(
+            f"| **Output calibration ratio** | {e.waste_output_calibration_ratio:.4f} "
+            f"(≈ billed output ÷ heuristic assistant spans; near **1.0** is good) |"
+        )
+        lines.append(f"| **Cache hit rate** | {e.cache_hit_rate * 100:.1f}% |")
+        pos = e.positional
+        lines.append(
+            f"| **Positional TER** | early {pos.early_ter:.2f} / mid {pos.mid_ter:.2f} / late {pos.late_ter:.2f} |"
+        )
+        if e.input_growth.context_bloat_detected:
+            lines.append("| **Context growth** | **BLOAT** detected |")
+        else:
+            lines.append(f"| **Context growth** | rate {e.input_growth.growth_rate:.2f}× |")
+    lines.append("")
+
+    lines.append("## Phase scores")
+    lines.append("")
+    for phase, score in result.phase_scores.items():
+        lines.append(f"- **{phase}**: {score:.3f}")
+    lines.append("")
+
+    patterns = sorted(
+        result.waste_patterns,
+        key=lambda p: p.tokens_wasted,
+        reverse=True,
+    )[:6]
+    if patterns:
+        lines.append("## Top structural waste patterns")
+        lines.append("")
+        for p in patterns:
+            lines.append(
+                f"- **{p.pattern_type}** — ~{p.tokens_wasted} tokens ({p.description[:120]}{'…' if len(p.description) > 120 else ''})"
+            )
+        lines.append("")
+
+    lines.append("## Suggested next steps")
+    lines.append("")
+    lines.append(
+        "- Tighten prompts or add `CLAUDE.md` rules for the **lowest phase TER** above."
+    )
+    if result.economics and result.economics.cache_hit_rate < 0.5:
+        lines.append(
+            "- **Cache hit rate** is low — stabilize prompt prefixes so Claude Code can cache."
+        )
+    if patterns:
+        top = patterns[0].pattern_type
+        lines.append(f"- Address **{top}** first (largest structural waste bucket).")
+    ia = result.input_analysis
+    if (
+        ia
+        and ia.prompt_similarity.prompt_redundancy_score > 0.2
+    ):
+        lines.append(
+            "- **Prompt redundancy** flagged — consolidate user asks to reduce back-and-forth."
+        )
+    lines.append("")
+
+    lines.append("---")
+    lines.append("")
+    lines.append(
+        "*Interpretation limits: TER uses heuristics and `len(text)//4` spans; waste $ uses "
+        "calibration to API `output_tokens` when present. See main README “Limits of interpretation”.*"
+    )
+    return "\n".join(lines)
+
+
+def format_baseline_markdown(
+    before: TERResult,
+    after: TERResult,
+    label_before: str = "Before",
+    label_after: str = "After",
+) -> str:
+    """Compare two sessions (e.g. rules change) — narrative + delta table."""
+    lines: list[str] = []
+    lines.append("# TER baseline comparison")
+    lines.append("")
+    lines.append(f"- **{label_before}**: `{before.session_id}`")
+    lines.append(f"- **{label_after}**: `{after.session_id}`")
+    lines.append("")
+
+    lines.append(f"| Metric | {label_before} | {label_after} | Δ |")
+    lines.append("|--------|------------|-----------|---|")
+    dt = after.aggregate_ter - before.aggregate_ter
+    lines.append(
+        f"| **TER** | {before.aggregate_ter:.4f} | {after.aggregate_ter:.4f} | {dt:+.4f} |"
+    )
+    wc_a = (before.waste_tokens / before.total_tokens) if before.total_tokens else 0.0
+    wc_b = (after.waste_tokens / after.total_tokens) if after.total_tokens else 0.0
+    lines.append(
+        f"| **Waste ratio** | {wc_a:.4f} | {wc_b:.4f} | {wc_b - wc_a:+.4f} |"
+    )
+    if before.economics and after.economics:
+        dc = after.economics.estimated_cost_usd - before.economics.estimated_cost_usd
+        lines.append(
+            f"| **Est. cost** | ${before.economics.estimated_cost_usd:.4f} | "
+            f"${after.economics.estimated_cost_usd:.4f} | ${dc:+.4f} |"
+        )
+    lines.append("")
+
+    lines.append("## Interpretation")
+    lines.append("")
+    lines.append(
+        "Positive **Δ TER** means the later session is more token-efficient on this heuristic. "
+        "Compare similar tasks only; different tasks make raw TER incomparable."
+    )
+    lines.append("")
+    return "\n".join(lines)

--- a/tests/unit/test_classifier.py
+++ b/tests/unit/test_classifier.py
@@ -44,7 +44,8 @@ class TestClassifySpan:
         label, conf = _classify_span(
             sim=0.8, phase=SpanPhase.REASONING,
             is_repetition=True, repetition_similarity=0.92,
-            similarity_threshold=0.40, span_text="some reasoning text",
+            similarity_threshold=0.40, confidence_threshold=0.75,
+            span_text="some reasoning text",
         )
         assert label == SpanLabel.REDUNDANT_REASONING
         assert conf == 0.92
@@ -54,16 +55,28 @@ class TestClassifySpan:
         label, conf = _classify_span(
             sim=0.5, phase=SpanPhase.TOOL_USE,
             is_repetition=True, repetition_similarity=0.90,
-            similarity_threshold=0.40, span_text="Bash ls -la",
+            similarity_threshold=0.40, confidence_threshold=0.75,
+            span_text="Bash ls -la",
         )
         assert label == SpanLabel.UNNECESSARY_TOOL_CALL
+
+    def test_weak_repetition_respects_confidence_threshold(self):
+        """Near-threshold self-similarity stays aligned when confidence bar is high."""
+        label, conf = _classify_span(
+            sim=0.5, phase=SpanPhase.REASONING,
+            is_repetition=True, repetition_similarity=0.76,
+            similarity_threshold=0.40, confidence_threshold=0.80,
+            span_text="thinking again",
+        )
+        assert label == SpanLabel.ALIGNED_REASONING
 
     def test_repetition_generation_is_waste(self):
         """Self-repetition in generation phase → over-explanation."""
         label, conf = _classify_span(
             sim=0.6, phase=SpanPhase.GENERATION,
             is_repetition=True, repetition_similarity=0.95,
-            similarity_threshold=0.40, span_text="here is the answer again",
+            similarity_threshold=0.40, confidence_threshold=0.75,
+            span_text="here is the answer again",
         )
         assert label == SpanLabel.OVER_EXPLANATION
 
@@ -72,7 +85,8 @@ class TestClassifySpan:
         label, conf = _classify_span(
             sim=0.3, phase=SpanPhase.REASONING,
             is_repetition=False, repetition_similarity=0.0,
-            similarity_threshold=0.40, span_text="Let me think about how to approach this problem step by step",
+            similarity_threshold=0.40, confidence_threshold=0.75,
+            span_text="Let me think about how to approach this problem step by step",
         )
         assert label == SpanLabel.ALIGNED_REASONING
 
@@ -81,7 +95,8 @@ class TestClassifySpan:
         label, conf = _classify_span(
             sim=0.05, phase=SpanPhase.REASONING,
             is_repetition=False, repetition_similarity=0.0,
-            similarity_threshold=0.40, span_text="hmm okay let me see",
+            similarity_threshold=0.40, confidence_threshold=0.75,
+            span_text="hmm okay let me see",
         )
         assert label == SpanLabel.REDUNDANT_REASONING
 
@@ -90,7 +105,8 @@ class TestClassifySpan:
         label, conf = _classify_span(
             sim=0.05, phase=SpanPhase.TOOL_USE,
             is_repetition=False, repetition_similarity=0.0,
-            similarity_threshold=0.40, span_text="Read some/file.py",
+            similarity_threshold=0.40, confidence_threshold=0.75,
+            span_text="Read some/file.py",
         )
         assert label == SpanLabel.ALIGNED_TOOL_CALL
 
@@ -99,7 +115,8 @@ class TestClassifySpan:
         label, conf = _classify_span(
             sim=0.2, phase=SpanPhase.GENERATION,
             is_repetition=False, repetition_similarity=0.0,
-            similarity_threshold=0.40, span_text="Here is your answer.",
+            similarity_threshold=0.40, confidence_threshold=0.75,
+            span_text="Here is your answer.",
         )
         assert label == SpanLabel.ALIGNED_RESPONSE
 
@@ -109,7 +126,8 @@ class TestClassifySpan:
         label, conf = _classify_span(
             sim=0.03, phase=SpanPhase.GENERATION,
             is_repetition=False, repetition_similarity=0.0,
-            similarity_threshold=0.40, span_text=long_text,
+            similarity_threshold=0.40, confidence_threshold=0.75,
+            span_text=long_text,
         )
         assert label == SpanLabel.OVER_EXPLANATION
 
@@ -118,7 +136,8 @@ class TestClassifySpan:
         label, conf = _classify_span(
             sim=0.9, phase=SpanPhase.REASONING,
             is_repetition=False, repetition_similarity=0.0,
-            similarity_threshold=0.40, span_text="analyzing the user's request for auth",
+            similarity_threshold=0.40, confidence_threshold=0.75,
+            span_text="analyzing the user's request for auth",
         )
         assert label == SpanLabel.ALIGNED_REASONING
         assert conf >= 0.5

--- a/tests/unit/test_economics.py
+++ b/tests/unit/test_economics.py
@@ -275,14 +275,16 @@ class TestInputGrowth:
 class TestEstimateWasteCost:
     def test_all_aligned_zero_waste(self):
         spans = [_make_classified(SpanLabel.ALIGNED_RESPONSE, token_count=100)]
-        cost = _estimate_waste_cost(spans, CostModel())
+        cost, ratio = _estimate_waste_cost(spans, CostModel())
         assert cost == 0.0
+        assert ratio == pytest.approx(1.0)
 
     def test_waste_tokens_costed_at_output_rate(self):
         spans = [_make_classified(SpanLabel.OVER_EXPLANATION, token_count=1_000_000)]
-        cost = _estimate_waste_cost(spans, CostModel())
+        cost, ratio = _estimate_waste_cost(spans, CostModel())
         # 1M waste tokens × $15/MTok = $15
         assert cost == pytest.approx(15.0)
+        assert ratio == pytest.approx(1.0)
 
     def test_mixed_spans(self):
         spans = [
@@ -290,14 +292,47 @@ class TestEstimateWasteCost:
             _make_classified(SpanLabel.OVER_EXPLANATION, token_count=200_000),
             _make_classified(SpanLabel.REDUNDANT_REASONING, token_count=300_000),
         ]
-        cost = _estimate_waste_cost(spans, CostModel())
+        cost, ratio = _estimate_waste_cost(spans, CostModel())
         # 500k waste tokens × $15/MTok = $7.50
         assert cost == pytest.approx(7.5)
+        assert ratio == pytest.approx(1.0)
 
     def test_custom_output_rate(self):
         spans = [_make_classified(SpanLabel.OVER_EXPLANATION, token_count=1_000_000)]
-        cost = _estimate_waste_cost(spans, CostModel(output_rate=30.0))
+        cost, ratio = _estimate_waste_cost(spans, CostModel(output_rate=30.0))
         assert cost == pytest.approx(30.0)
+        assert ratio == pytest.approx(1.0)
+
+    def test_calibration_scales_to_billed_output(self):
+        spans = [_make_classified(SpanLabel.OVER_EXPLANATION, token_count=100)]
+        cost, ratio = _estimate_waste_cost(
+            spans, CostModel(), billed_output_tokens=400,
+        )
+        assert ratio == pytest.approx(4.0)
+        assert cost == pytest.approx(400 * 15.0 / 1_000_000)
+
+    def test_user_origin_waste_not_in_output_waste_cost(self):
+        span = TokenSpan(
+            text="x",
+            phase=SpanPhase.GENERATION,
+            position=0,
+            token_count=500_000,
+            source_message_uuid="u1",
+            source_role="user",
+        )
+        spans = [
+            ClassifiedSpan(
+                span=span,
+                label=SpanLabel.OVER_EXPLANATION,
+                confidence=0.5,
+                cosine_similarity=0.1,
+            ),
+        ]
+        cost, ratio = _estimate_waste_cost(
+            spans, CostModel(), billed_output_tokens=100,
+        )
+        assert cost == 0.0
+        assert ratio == pytest.approx(1.0)
 
 
 class TestComputeEconomics:

--- a/tests/unit/test_session_report.py
+++ b/tests/unit/test_session_report.py
@@ -1,0 +1,73 @@
+"""Tests for Markdown session report and baseline formatting."""
+
+from ter_calculator.models import (
+    CostModel,
+    InputAnalysis,
+    InputGrowth,
+    PositionalBreakdown,
+    PromptSimilarityResult,
+    SessionEconomics,
+    TERResult,
+)
+from ter_calculator.session_report import (
+    format_baseline_markdown,
+    format_session_report_markdown,
+)
+
+
+def _minimal_result(session_id: str, ter: float, waste: int, total: int) -> TERResult:
+    econ = SessionEconomics(
+        total_input_tokens=1000,
+        total_output_tokens=500,
+        total_cache_creation_tokens=0,
+        total_cache_read_tokens=2000,
+        input_output_ratio=0.5,
+        cache_hit_rate=0.8,
+        estimated_cost_usd=0.05,
+        estimated_waste_cost_usd=0.01,
+        cost_model=CostModel(),
+        positional=PositionalBreakdown(
+            early_ter=0.8,
+            mid_ter=0.7,
+            late_ter=0.75,
+            early_span_count=10,
+            mid_span_count=10,
+            late_span_count=10,
+        ),
+        input_growth=InputGrowth(
+            turn_input_tokens=[100, 200],
+            growth_rate=2.0,
+            is_superlinear=False,
+            context_bloat_detected=False,
+        ),
+        waste_output_calibration_ratio=0.95,
+    )
+    return TERResult(
+        session_id=session_id,
+        aggregate_ter=ter,
+        raw_ratio=0.9,
+        phase_scores={"reasoning": 0.8, "tool_use": 0.85, "generation": 0.82},
+        total_tokens=total,
+        aligned_tokens=total - waste,
+        waste_tokens=waste,
+        waste_patterns=[],
+        economics=econ,
+        input_analysis=InputAnalysis(prompt_similarity=PromptSimilarityResult()),
+    )
+
+
+def test_report_markdown_contains_session_and_ter():
+    r = _minimal_result("abc", 0.85, 100, 1000)
+    md = format_session_report_markdown(r)
+    assert "abc" in md
+    assert "0.850" in md or "0.85" in md
+    assert "Calibration" in md or "calibration" in md
+
+
+def test_baseline_markdown_delta():
+    a = _minimal_result("before", 0.70, 200, 1000)
+    b = _minimal_result("after", 0.80, 150, 1000)
+    md = format_baseline_markdown(a, b)
+    assert "before" in md
+    assert "after" in md
+    assert "TER" in md


### PR DESCRIPTION
## Purpose

This PR focuses on **measurement honesty and usability**, not on chasing a “better” TER score. The goal is to make **dollars, attribution, and breakdown tables** line up with how Claude Code sessions are actually billed and represented, and to add **human-facing** commands so teams can act on a session without parsing Rich/JSON only.

---

## Angle of improvement

### 1. Trustworthy economics and attribution

- **`source_role` on spans** — Separates assistant-origin text from user/context (e.g. tool results) so “output waste $” is not mixed with user-side spans.
- **Calibration** — When usage includes `output_tokens`, waste dollars can be scaled toward **billed** output via `waste_output_calibration_ratio` (heuristic span counts rarely match the tokenizer).
- **Input vs output pricing in the waste breakdown** — Re-injected context is not priced at output $/MTok when it behaves like **input-side** context.
- **Overlap rules in the waste breakdown** — Avoids **double-counting** when both the classifier and structural patterns (e.g. duplicate tool / restatement) describe the same failure mode (same spirit as the existing `reasoning_loop` overlap).
- **Classifier CLI wiring** — `--confidence-threshold` and `--similarity-threshold` are connected to classifier behavior as documented.

Details, rationale, and before/after intuition: **[`UPDATES.md`](UPDATES.md)** (maintainer-oriented design log).

### 2. Consistent pipeline and new entry points

- **`analyze_pipeline.py` + `config_parse.py`** — Single `analyze_session()` path so `analyze` and `report` do not drift.
- **`ter report`** — Markdown summary (same analysis flags as `analyze` where applicable); **`-o` / `--output FILE`** writes e.g. `report.md`.
- **`ter compare --baseline`** — Two sessions → Markdown delta (before/after narrative). Currently uses **default analyze thresholds** only; exposing full analyze flags on compare is left as follow-up.

### 3. Transparency for users

- **README — “Limits of interpretation”** — Heuristics, `len(text)//4`, calibration meaning, TER ≠ ground truth labels.

---

## Where to find decisions and deep context

| Document | What it contains |
|----------|------------------|
| **[`docs/TER_GOAL_AND_CHANGES.md`](docs/TER_GOAL_AND_CHANGES.md)** | End goal, summary of changes, **maintainer decisions** (versioning branch vs semver bump, `ter report -o`, open question on `compare --baseline` flags), and **recommended next steps**. |
| **[`UPDATES.md`](UPDATES.md)** | Measurement pass: tables, thought process (including **double-counting** and related fixes), files touched, future ideas. |

---

## How to verify

```bash
pip install -e ".[dev]"
pytest tests/ -q
ter analyze tests/fixtures/sample_session.jsonl
ter report tests/fixtures/sample_session.jsonl -o report.md
ter compare tests/fixtures/sample_session.jsonl tests/fixtures/sample_session.jsonl --baseline