### PR TITLE
Fix live watch alignment, polling, and add --log output

### DIFF
--- a/src/ter_calculator/__main__.py
+++ b/src/ter_calculator/__main__.py
@@ -1,0 +1,3 @@
+from ter_calculator.cli import main
+
+raise SystemExit(main())

--- a/src/ter_calculator/cli.py
+++ b/src/ter_calculator/cli.py
@@ -219,6 +219,10 @@ def main(argv: list[str] | None = None) -> int:
         "--model", type=str, default=None,
         help="Path to custom sentence-transformers model (optional)"
     )
+    watch_parser.add_argument(
+        "--log", dest="log_file", metavar="FILE", default=None,
+        help="Append signals as JSONL to FILE for later analysis"
+    )
 
     # budget subcommand
     budget_parser = subparsers.add_parser(
@@ -567,28 +571,42 @@ def _cmd_budget(args) -> int:
     return 0
 
 
-def _print_signal(signal, fmt):
+def _signal_to_dict(signal) -> dict:
+    """Convert a TERSignal to a JSON-serialisable dict."""
+    from datetime import datetime, timezone
+
+    return {
+        "session_id": signal.session_id,
+        "timestamp": datetime.fromtimestamp(signal.timestamp, tz=timezone.utc).isoformat(),
+        "ter": round(signal.aggregate_ter, 4),
+        "raw_ratio": round(signal.raw_ratio, 4),
+        "message_index": signal.message_index,
+        "drift": signal.drift.value,
+        "drift_magnitude": round(signal.drift_magnitude, 4),
+        "warnings": signal.warnings,
+        "warning_level": signal.warning_level.value,
+        "tokens": {
+            "total": signal.total_tokens,
+            "aligned": signal.aligned_tokens,
+            "waste": signal.waste_tokens,
+        },
+        "phase_ter": getattr(signal, "phase_ter", {}),
+        "waste_sources": getattr(signal, "waste_sources", {}),
+    }
+
+
+def _print_signal(signal, fmt, log_fh=None):
     """Format and print a TER signal from live monitoring."""
     import json as json_mod
 
+    record = _signal_to_dict(signal)
+
+    if log_fh is not None:
+        log_fh.write(json_mod.dumps(record) + "\n")
+        log_fh.flush()
+
     if fmt == "json":
-        print(json_mod.dumps({
-            "session_id": signal.session_id,
-            "timestamp": signal.timestamp.isoformat(),
-            "ter": round(signal.aggregate_ter, 4),
-            "raw_ratio": round(signal.raw_ratio, 4),
-            "drift": signal.drift.value,
-            "drift_magnitude": round(signal.drift_magnitude, 4),
-            "warnings": signal.warnings,
-            "warning_level": signal.warning_level.value,
-            "tokens": {
-                "total": signal.total_tokens,
-                "aligned": signal.aligned_tokens,
-                "waste": signal.waste_tokens
-            },
-            "phase_ter": getattr(signal, 'phase_ter', {}),
-            "waste_sources": getattr(signal, 'waste_sources', {})
-        }))
+        print(json_mod.dumps(record))
     else:
         # Text format with drift indicators
         drift_arrow = "↑" if signal.drift.value == "improving" else "↓" if signal.drift.value == "degrading" else "→"
@@ -630,7 +648,6 @@ def _cmd_watch(args) -> int:
     if args.latest:
         from .loader import find_latest_session
         latest_session = find_latest_session(args.project_path)
-        # For watch, we need the project directory, not the session file
         project_path = latest_session.parent
         if not args.quiet:
             print(f"Watching latest session: {latest_session.name}", file=sys.stderr)
@@ -644,30 +661,47 @@ def _cmd_watch(args) -> int:
         print(f"Error: Project path not found: {project_path}", file=sys.stderr)
         return 1
 
-    # Create dashboard
+    log_fh = None
+    log_path = getattr(args, "log_file", None)
+    signal_count = 0
+
     try:
+        if log_path:
+            log_fh = open(log_path, "a", encoding="utf-8")
+
+        def on_signal(sig):
+            nonlocal signal_count
+            signal_count += 1
+            _print_signal(sig, args.output_format, log_fh=log_fh)
+
         dashboard = LiveDashboard(
             project_dir=project_path,
             poll_interval=args.poll_interval,
-            model=None,  # Use fast trigram embeddings
-            on_signal=lambda sig: _print_signal(sig, args.output_format)
+            model=None,
+            on_signal=on_signal,
         )
     except Exception as e:
         print(f"Error initializing dashboard: {e}", file=sys.stderr)
         if args.verbose:
             import traceback
             traceback.print_exc(file=sys.stderr)
+        if log_fh:
+            log_fh.close()
         return 1
 
     try:
         if args.output_format == "text":
             print(f"Watching: {project_path}")
+            if log_path:
+                print(f"Logging to: {log_path}")
             print("Press Ctrl+C to stop...\n")
-        dashboard.run()  # Blocking call
+        dashboard.run()
     except KeyboardInterrupt:
         dashboard.stop()
         if args.output_format == "text":
             print("\nStopped monitoring.")
+            if log_path:
+                print(f"Wrote {signal_count} signals to {log_path}")
         return 0
     except Exception as e:
         print(f"Error: {e}", file=sys.stderr)
@@ -675,6 +709,9 @@ def _cmd_watch(args) -> int:
             import traceback
             traceback.print_exc(file=sys.stderr)
         return 1
+    finally:
+        if log_fh:
+            log_fh.close()
 
     return 0
 

--- a/src/ter_calculator/cli.py
+++ b/src/ter_calculator/cli.py
@@ -578,6 +578,7 @@ def _signal_to_dict(signal) -> dict:
     return {
         "session_id": signal.session_id,
         "timestamp": datetime.fromtimestamp(signal.timestamp, tz=timezone.utc).isoformat(),
+        "is_live": signal.is_live,
         "ter": round(signal.aggregate_ter, 4),
         "raw_ratio": round(signal.raw_ratio, 4),
         "message_index": signal.message_index,
@@ -595,8 +596,12 @@ def _signal_to_dict(signal) -> dict:
     }
 
 
+_last_was_live = False
+
+
 def _print_signal(signal, fmt, log_fh=None):
     """Format and print a TER signal from live monitoring."""
+    global _last_was_live
     import json as json_mod
 
     record = _signal_to_dict(signal)
@@ -608,13 +613,19 @@ def _print_signal(signal, fmt, log_fh=None):
     if fmt == "json":
         print(json_mod.dumps(record))
     else:
-        # Text format with drift indicators
+        from datetime import datetime, timezone
+
+        if signal.is_live and not _last_was_live:
+            print("\n--- LIVE ---\n")
+        _last_was_live = signal.is_live
+
+        tag = "LIVE" if signal.is_live else "HISTORY"
+        msg_time = datetime.fromtimestamp(signal.timestamp, tz=timezone.utc).astimezone().strftime("%H:%M:%S")
         drift_arrow = "↑" if signal.drift.value == "improving" else "↓" if signal.drift.value == "degrading" else "→"
         waste_pct = (signal.waste_tokens / signal.total_tokens * 100) if signal.total_tokens > 0 else 0
         aligned_pct = (signal.aligned_tokens / signal.total_tokens * 100) if signal.total_tokens > 0 else 0
 
-        # Show both aggregate TER (phase-weighted) and raw ratio (actual waste %)
-        print(f"[{signal.session_id[:8]}] TER: {signal.aggregate_ter:.2f} (weighted) | "
+        print(f"[{msg_time}] [{tag}] [{signal.session_id[:8]}] TER: {signal.aggregate_ter:.2f} (weighted) | "
               f"Raw: {signal.raw_ratio:.2f} {drift_arrow} | "
               f"Tokens: {signal.total_tokens:,} | "
               f"Aligned: {signal.aligned_tokens:,} ({aligned_pct:.0f}%) | "

--- a/src/ter_calculator/cli.py
+++ b/src/ter_calculator/cli.py
@@ -652,25 +652,27 @@ def _print_signal(signal, fmt, log_fh=None):
 
 def _cmd_watch(args) -> int:
     """Execute the watch subcommand for live session monitoring."""
-    from .real_time import LiveDashboard
+    from .real_time import LiveDashboard, SessionMonitor
     from pathlib import Path
 
-    # Resolve --latest flag
+    single_file = None
+
     if args.latest:
         from .loader import find_latest_session
         latest_session = find_latest_session(args.project_path)
-        project_path = latest_session.parent
+        single_file = latest_session
         if not args.quiet:
             print(f"Watching latest session: {latest_session.name}", file=sys.stderr)
     elif args.project_path is None:
         print("Error: Either provide a project_path or use --latest", file=sys.stderr)
         return 1
     else:
-        project_path = Path(args.project_path)
-
-    if not project_path.exists():
-        print(f"Error: Project path not found: {project_path}", file=sys.stderr)
-        return 1
+        target = Path(args.project_path)
+        if target.is_file() and target.suffix == ".jsonl":
+            single_file = target
+        elif not target.exists():
+            print(f"Error: Project path not found: {target}", file=sys.stderr)
+            return 1
 
     log_fh = None
     log_path = getattr(args, "log_file", None)
@@ -685,14 +687,22 @@ def _cmd_watch(args) -> int:
             signal_count += 1
             _print_signal(sig, args.output_format, log_fh=log_fh)
 
-        dashboard = LiveDashboard(
-            project_dir=project_path,
-            poll_interval=args.poll_interval,
-            model=None,
-            on_signal=on_signal,
-        )
+        if single_file is not None:
+            monitor = SessionMonitor(
+                single_file,
+                poll_interval=args.poll_interval,
+                model=None,
+                on_signal=on_signal,
+            )
+        else:
+            monitor = LiveDashboard(
+                project_dir=Path(args.project_path),
+                poll_interval=args.poll_interval,
+                model=None,
+                on_signal=on_signal,
+            )
     except Exception as e:
-        print(f"Error initializing dashboard: {e}", file=sys.stderr)
+        print(f"Error initializing monitor: {e}", file=sys.stderr)
         if args.verbose:
             import traceback
             traceback.print_exc(file=sys.stderr)
@@ -700,15 +710,16 @@ def _cmd_watch(args) -> int:
             log_fh.close()
         return 1
 
+    watch_target = single_file or args.project_path
     try:
         if args.output_format == "text":
-            print(f"Watching: {project_path}")
+            print(f"Watching: {watch_target}")
             if log_path:
                 print(f"Logging to: {log_path}")
             print("Press Ctrl+C to stop...\n")
-        dashboard.run()
+        monitor.run()
     except KeyboardInterrupt:
-        dashboard.stop()
+        monitor.stop()
         if args.output_format == "text":
             print("\nStopped monitoring.")
             if log_path:

--- a/src/ter_calculator/real_time.py
+++ b/src/ter_calculator/real_time.py
@@ -238,6 +238,33 @@ def _embed_text_fast(text: str) -> NDArray[np.float32]:
     return vec
 
 
+def _is_aligned(sim: float, phase: str, text: str) -> bool:
+    """Classify a span as aligned or waste, mirroring classifier.py philosophy.
+
+    Aligned by default. Only waste if a specific signal fires:
+    - Tool calls are always aligned (actions, not words).
+    - Reasoning is waste only if below threshold AND short filler.
+    - Generation is waste only if below threshold AND long verbose text.
+
+    Thresholds are derived from SIM_THRESHOLD to work with both trigram-hash
+    and sentence-transformer embeddings.
+    """
+    if phase == "tool_use":
+        return True
+
+    if phase == "reasoning":
+        if sim < SIM_THRESHOLD and len(text.split()) < 15:
+            return False
+        return True
+
+    if phase == "generation":
+        if sim < SIM_THRESHOLD and len(text.split()) > 50:
+            return False
+        return True
+
+    return True
+
+
 def _extract_blocks_from_line(line_data: dict[str, Any]) -> list[dict[str, Any]]:
     """Pull content blocks from a JSONL line."""
     msg = line_data.get("message", {})
@@ -332,14 +359,15 @@ def compute_rolling_ter(
                             else:
                                 span_emb = _embed_text_fast(text)
                             sim = _cosine_similarity(span_emb, state.intent_embedding)
-                            is_aligned = sim >= SIM_THRESHOLD
+                            aligned = _is_aligned(sim, phase, text)
                         else:
-                            is_aligned = True
-                        if is_aligned:
+                            aligned = True
+                        if aligned:
                             state.aligned_tokens += tokens
                             state.phase_aligned[phase] += tokens
                         else:
                             state.waste_tokens += tokens
+                            state.phase_waste[phase] += tokens
             continue
 
         if role != "assistant":
@@ -379,11 +407,11 @@ def compute_rolling_ter(
                 else:
                     span_emb = _embed_text_fast(text)
                 sim = _cosine_similarity(span_emb, state.intent_embedding)
-                is_aligned = sim >= SIM_THRESHOLD
+                aligned = _is_aligned(sim, phase, text)
             else:
-                is_aligned = True
+                aligned = True
 
-            if is_aligned:
+            if aligned:
                 state.aligned_tokens += tokens
                 state.phase_aligned[phase] += tokens
                 message_aligned += tokens
@@ -504,26 +532,25 @@ class SessionMonitor:
         self.on_signal = on_signal
         self.state = RollingTERState()
         self._stop = False
-        self._lines_read = 0
+        self._file_pos = 0
 
     def _read_new_lines(self) -> list[dict[str, Any]]:
-        """Read lines added since last poll."""
+        """Read lines appended since last poll using byte-offset seek."""
         if not self.path.exists():
             return []
         new_lines: list[dict[str, Any]] = []
         try:
             with open(self.path, "r", encoding="utf-8") as fh:
-                for i, raw in enumerate(fh):
-                    if i < self._lines_read:
-                        continue
+                fh.seek(self._file_pos)
+                for raw in fh:
                     raw = raw.strip()
                     if not raw:
                         continue
                     try:
                         new_lines.append(json.loads(raw))
                     except json.JSONDecodeError:
-                        logger.debug("Skipping malformed JSONL line %d", i)
-                self._lines_read = i + 1 if new_lines else self._lines_read
+                        logger.debug("Skipping malformed JSONL line")
+                self._file_pos = fh.tell()
         except OSError as exc:
             logger.warning("Could not read %s: %s", self.path, exc)
         return new_lines

--- a/src/ter_calculator/real_time.py
+++ b/src/ter_calculator/real_time.py
@@ -186,6 +186,7 @@ class TERSignal:
     waste_tokens: int
     drift: DriftDirection
     drift_magnitude: float
+    is_live: bool = False
     warnings: list[str] = field(default_factory=list)
     warning_level: WarningLevel = WarningLevel.INFO
     phase_ter: dict[str, float] = field(default_factory=dict)
@@ -286,6 +287,24 @@ def _get_usage(line_data: dict[str, Any]) -> dict[str, int]:
     """Extract token usage dict."""
     msg = line_data.get("message", {})
     return msg.get("usage", {})
+
+
+def _get_message_timestamp(line_data: dict[str, Any]) -> float:
+    """Extract the message timestamp as a unix float, falling back to now."""
+    ts = line_data.get("timestamp")
+    if isinstance(ts, (int, float)):
+        return float(ts)
+    if isinstance(ts, str):
+        from datetime import datetime, timezone
+        try:
+            dt = datetime.fromisoformat(ts.replace("Z", "+00:00"))
+            return dt.timestamp()
+        except ValueError:
+            pass
+    return time.time()
+
+
+_LIVE_THRESHOLD_SEC = 30.0
 
 
 def compute_rolling_ter(
@@ -461,9 +480,10 @@ def compute_rolling_ter(
             if waste > 0:
                 waste_sources[phase] = waste
 
+        msg_ts = _get_message_timestamp(line_data)
         signal = TERSignal(
             session_id=line_data.get("sessionId", "unknown"),
-            timestamp=time.time(),
+            timestamp=msg_ts,
             aggregate_ter=current_ter,
             raw_ratio=ratio,
             message_index=state.message_count,
@@ -474,6 +494,7 @@ def compute_rolling_ter(
             drift_magnitude=drift_mag,
             warnings=warnings,
             warning_level=level,
+            is_live=(time.time() - msg_ts) < _LIVE_THRESHOLD_SEC,
             phase_ter=phase_ter,
             waste_sources=waste_sources,
         )

--- a/tests/features/steps/realtime_steps.py
+++ b/tests/features/steps/realtime_steps.py
@@ -445,9 +445,11 @@ def rolling_state_with_recent_values(ctx, values):
     state.aligned_tokens = 300
     state.waste_tokens = 200
     state.message_count = len(parsed)
-    # Set up intent so classification works
-    state.intent_embedding = np.ones(384, dtype=np.float32) / np.sqrt(384)
-    state.intent_text = "test intent"
+    # Set up intent with a realistic embedding (not uniform, which has
+    # artificially high similarity to everything via trigram hashing).
+    from ter_calculator.real_time import _embed_text_fast
+    state.intent_embedding = _embed_text_fast("fix the authentication bug in login flow")
+    state.intent_text = "fix the authentication bug in login flow"
     state.intent_confidence = 1.0
     ctx["state"] = state
 
@@ -455,8 +457,15 @@ def rolling_state_with_recent_values(ctx, values):
 @when("the next assistant message produces a TER that continues the decline")
 def next_declining_message(ctx):
     state = ctx["state"]
-    # Produce a message that will have low TER to continue the decline
-    line = _make_assistant_line("Completely unrelated tangent about cooking recipes and gardening tips.")
+    # Produce a long generation message (>50 words) with low intent similarity
+    # to trigger waste classification under the aligned-by-default logic.
+    line = _make_assistant_line(
+        "Completely unrelated tangent about cooking recipes and gardening tips. "
+        "First you need to preheat the oven to three hundred and fifty degrees "
+        "then prepare the batter by mixing flour sugar eggs and butter together "
+        "in a large bowl until smooth. Pour the mixture into a greased pan and "
+        "bake for approximately thirty minutes until golden brown on top."
+    )
     signals = compute_rolling_ter(state, [line])
     ctx["signals"] = signals
     ctx["signal"] = signals[0] if signals else None


### PR DESCRIPTION
## Summary

- **Fixed live vs post-hoc TER divergence**: Replaced the binary similarity gate (`sim >= 0.40 → aligned, else waste`) with the classifier's "aligned by default" philosophy — tool calls always aligned, reasoning waste only for low-sim + short filler, generation waste only for low-sim + long verbose text
- **Fixed file polling**: Replaced buggy line-counting with byte-offset `seek()` so new lines appended to the JSONL are correctly detected on each poll cycle
- **Added `--log` flag**: `ter watch --log signals.jsonl` appends every signal as a JSONL line for later analysis. Fixed a crash in JSON output mode (`float.isoformat()` on a unix timestamp)
- **Added `__main__.py`**: `python -m ter_calculator` now works
- **Added timestamps and LIVE/HISTORY tags**: Each signal shows `[HH:MM:SS] [LIVE/HISTORY]` using the message's own timestamp from the JSONL. A `--- LIVE ---` separator prints when transitioning from historical replay to live signals
- **Fixed `--latest` to watch single session**: Previously `--latest` resolved to a session file but then watched the entire parent directory, replaying all sessions. Now it uses `SessionMonitor` directly on the single file. Direct `.jsonl` file paths are also supported

## Test plan

- [x] All 538 tests pass
- [x] `ter watch --latest` watches only the latest session file
- [x] `--log` flag produces valid JSONL output
- [x] Timestamps show actual message times, not processing time
- [x] `[HISTORY]` / `[LIVE]` tags correctly distinguish replay from real-time
- [x] Byte-offset polling correctly detects new lines
- [x] Manual: verified live polling against active Hadur Robot session

🤖 Generated with [Claude Code](https://claude.com/claude-code)