### PR TITLE
Fix live watch: waste classification, history replay, and session resolution

### DIFF
--- a/src/ter_calculator/cli.py
+++ b/src/ter_calculator/cli.py
@@ -611,12 +611,12 @@ def _print_signal(signal, fmt, log_fh=None):
         log_fh.flush()
 
     if fmt == "json":
-        print(json_mod.dumps(record))
+        print(json_mod.dumps(record), flush=True)
     else:
         from datetime import datetime, timezone
 
         if signal.is_live and not _last_was_live:
-            print("\n--- LIVE ---\n")
+            print("\n--- LIVE ---\n", flush=True)
         _last_was_live = signal.is_live
 
         tag = "LIVE" if signal.is_live else "HISTORY"
@@ -629,12 +629,12 @@ def _print_signal(signal, fmt, log_fh=None):
               f"Raw: {signal.raw_ratio:.2f} {drift_arrow} | "
               f"Tokens: {signal.total_tokens:,} | "
               f"Aligned: {signal.aligned_tokens:,} ({aligned_pct:.0f}%) | "
-              f"Waste: {signal.waste_tokens:,} ({waste_pct:.0f}%)")
+              f"Waste: {signal.waste_tokens:,} ({waste_pct:.0f}%)", flush=True)
 
         # Show phase breakdown if available
         if hasattr(signal, 'phase_ter') and signal.phase_ter:
             phase_strs = [f"{p[:3]}: {ter:.2f}" for p, ter in signal.phase_ter.items()]
-            print(f"  Phases: {' | '.join(phase_strs)}")
+            print(f"  Phases: {' | '.join(phase_strs)}", flush=True)
 
         # Show waste sources if available
         if hasattr(signal, 'waste_sources') and signal.waste_sources:
@@ -643,11 +643,11 @@ def _print_signal(signal, fmt, log_fh=None):
                 if count > 0:
                     waste_items.append(f"{source}: {count}")
             if waste_items:
-                print(f"  Waste: {', '.join(waste_items)}")
+                print(f"  Waste: {', '.join(waste_items)}", flush=True)
 
         if signal.warnings:
             for warning in signal.warnings:
-                print(f"  ⚠ {warning}")
+                print(f"  ⚠ {warning}", flush=True)
 
 
 def _cmd_watch(args) -> int:
@@ -670,6 +670,12 @@ def _cmd_watch(args) -> int:
         target = Path(args.project_path)
         if target.is_file() and target.suffix == ".jsonl":
             single_file = target
+        elif target.is_dir():
+            session_jsonl = target.parent / (target.name + ".jsonl")
+            if session_jsonl.is_file():
+                single_file = session_jsonl
+                if not args.quiet:
+                    print(f"Watching session file: {session_jsonl.name}", file=sys.stderr)
         elif not target.exists():
             print(f"Error: Project path not found: {target}", file=sys.stderr)
             return 1
@@ -713,10 +719,10 @@ def _cmd_watch(args) -> int:
     watch_target = single_file or args.project_path
     try:
         if args.output_format == "text":
-            print(f"Watching: {watch_target}")
+            print(f"Watching: {watch_target}", flush=True)
             if log_path:
-                print(f"Logging to: {log_path}")
-            print("Press Ctrl+C to stop...\n")
+                print(f"Logging to: {log_path}", flush=True)
+            print("Press Ctrl+C to stop...\n", flush=True)
         monitor.run()
     except KeyboardInterrupt:
         monitor.stop()

--- a/src/ter_calculator/real_time.py
+++ b/src/ter_calculator/real_time.py
@@ -23,6 +23,7 @@ import json
 import logging
 import math
 import os
+import re
 import time
 from dataclasses import dataclass, field
 from enum import Enum
@@ -71,6 +72,40 @@ PHASE_WEIGHTS: dict[str, float] = {
 
 SIM_THRESHOLD = 0.40
 CONF_THRESHOLD = 0.75
+
+_SIM_REASONING = 0.55
+"""Similarity floor for reasoning spans — trigram hashing yields ~0.3–0.5
+between unrelated English text, so 0.40 barely fires."""
+
+_SIM_GENERATION = 0.50
+"""Similarity floor for generation spans."""
+
+_SIM_FLOOR = 0.25
+"""Below this, content is clearly off-topic regardless of length."""
+
+_TOOL_DEDUP_WINDOW = 10
+"""How many recent tool signatures to keep for duplicate detection."""
+
+_REPEATED_CMD_THRESHOLD = 3
+"""Bash command must repeat this many times to count as waste."""
+
+_BASH_ANTIPATTERN_RES: list[re.Pattern[str]] = [
+    re.compile(r"(?:^|\|\s*)cat\s+"),
+    re.compile(r"(?:^|\|\s*)head\s+"),
+    re.compile(r"(?:^|\|\s*)tail\s+"),
+    re.compile(r"(?:^|\|\s*)grep\s+"),
+    re.compile(r"(?:^|\|\s*)rg\s+"),
+    re.compile(r"^find\s+"),
+]
+
+_ERROR_MARKERS = [
+    "<tool_use_error>",
+    "File does not exist",
+    "command not found",
+    "No such file or directory",
+    "Permission denied",
+    "File has not been read yet",
+]
 
 _BLOCK_TYPE_TO_PHASE: dict[str, str] = {
     "thinking": "reasoning",
@@ -140,6 +175,11 @@ class RollingTERState:
 
     last_request_ids: dict[str, int] = field(default_factory=dict)
     last_file_position: int = 0
+
+    tool_signatures: list[str] = field(default_factory=list)
+    file_read_counts: dict[str, int] = field(default_factory=dict)
+    bash_command_counts: dict[str, int] = field(default_factory=dict)
+    waste_by_type: dict[str, int] = field(default_factory=dict)
 
     @property
     def aggregate_ter(self) -> float:
@@ -240,30 +280,98 @@ def _embed_text_fast(text: str) -> NDArray[np.float32]:
 
 
 def _is_aligned(sim: float, phase: str, text: str) -> bool:
-    """Classify a span as aligned or waste, mirroring classifier.py philosophy.
+    """Classify a span as aligned or waste based on intent similarity.
 
-    Aligned by default. Only waste if a specific signal fires:
-    - Tool calls are always aligned (actions, not words).
-    - Reasoning is waste only if below threshold AND short filler.
-    - Generation is waste only if below threshold AND long verbose text.
-
-    Thresholds are derived from SIM_THRESHOLD to work with both trigram-hash
-    and sentence-transformer embeddings.
+    Thresholds are calibrated for the trigram-hash embedding, which yields
+    moderate cosine similarity (~0.3–0.5) even between unrelated English
+    texts.  Tool-use pattern waste (duplicates, antipatterns) is handled
+    separately by _check_tool_patterns.
     """
     if phase == "tool_use":
         return True
 
+    word_count = len(text.split())
+
+    if sim < _SIM_FLOOR and word_count > 5:
+        return False
+
     if phase == "reasoning":
-        if sim < SIM_THRESHOLD and len(text.split()) < 15:
+        if sim < _SIM_REASONING and word_count > 25:
             return False
         return True
 
     if phase == "generation":
-        if sim < SIM_THRESHOLD and len(text.split()) > 50:
+        if sim < _SIM_GENERATION and word_count > 20:
             return False
         return True
 
     return True
+
+
+def _is_bash_antipattern(cmd: str) -> bool:
+    """Check if a Bash command should use a dedicated tool instead."""
+    cmd = cmd.strip()
+    return any(p.search(cmd) for p in _BASH_ANTIPATTERN_RES)
+
+
+def _normalize_bash_cmd(cmd: str) -> str:
+    """Normalize a bash command for repeat detection."""
+    cmd = cmd.strip()
+    cmd = re.sub(r'\s*\|\s*(tail|head)\s+-\d+\s*$', '', cmd)
+    cmd = re.sub(r'\s+', ' ', cmd)
+    return cmd
+
+
+def _has_error_markers(text: str) -> bool:
+    """Check if tool result text indicates an error."""
+    if text.startswith("Error:") or text.startswith("Exit code 1"):
+        return True
+    return any(marker in text for marker in _ERROR_MARKERS)
+
+
+def _check_tool_patterns(
+    state: RollingTERState,
+    block: dict[str, Any],
+) -> tuple[bool, str]:
+    """Check a tool_use block for waste patterns.
+
+    Returns (is_aligned, waste_type).  Mutates state to track history.
+    """
+    tool_name = block.get("name", "")
+    tool_input = block.get("input", {})
+
+    sig = f"{tool_name}:{json.dumps(tool_input, sort_keys=True)}"
+
+    recent = state.tool_signatures[-_TOOL_DEDUP_WINDOW:]
+    is_duplicate = sig in recent
+    state.tool_signatures.append(sig)
+    if len(state.tool_signatures) > _TOOL_DEDUP_WINDOW * 2:
+        state.tool_signatures = state.tool_signatures[-_TOOL_DEDUP_WINDOW * 2:]
+
+    if is_duplicate:
+        return False, "duplicate_tool_call"
+
+    if tool_name == "Read":
+        fp = tool_input.get("file_path", "")
+        if fp:
+            count = state.file_read_counts.get(fp, 0) + 1
+            state.file_read_counts[fp] = count
+            if count > 1:
+                return False, "repetitive_read"
+
+    if tool_name == "Bash":
+        cmd = tool_input.get("command", "")
+        if cmd:
+            if _is_bash_antipattern(cmd):
+                return False, "bash_antipattern"
+            norm = _normalize_bash_cmd(cmd)
+            if norm:
+                count = state.bash_command_counts.get(norm, 0) + 1
+                state.bash_command_counts[norm] = count
+                if count >= _REPEATED_CMD_THRESHOLD:
+                    return False, "repeated_command"
+
+    return True, ""
 
 
 def _extract_blocks_from_line(line_data: dict[str, Any]) -> list[dict[str, Any]]:
@@ -370,7 +478,11 @@ def compute_rolling_ter(
                         state.total_tokens += tokens
                         state.phase_total[phase] += tokens
                         state.span_count += 1
-                        if state.intent_embedding is not None:
+                        waste_type = ""
+                        if _has_error_markers(text):
+                            aligned = False
+                            waste_type = "failed_tool"
+                        elif state.intent_embedding is not None:
                             if embed_fn is not None:
                                 span_emb = embed_fn(
                                     text, normalize_embeddings=True
@@ -387,6 +499,10 @@ def compute_rolling_ter(
                         else:
                             state.waste_tokens += tokens
                             state.phase_waste[phase] += tokens
+                            if waste_type:
+                                state.waste_by_type[waste_type] = (
+                                    state.waste_by_type.get(waste_type, 0) + tokens
+                                )
             continue
 
         if role != "assistant":
@@ -430,6 +546,10 @@ def compute_rolling_ter(
             else:
                 aligned = True
 
+            waste_type = ""
+            if block_type == "tool_use" and aligned:
+                aligned, waste_type = _check_tool_patterns(state, block)
+
             if aligned:
                 state.aligned_tokens += tokens
                 state.phase_aligned[phase] += tokens
@@ -437,6 +557,10 @@ def compute_rolling_ter(
             else:
                 state.waste_tokens += tokens
                 state.phase_waste[phase] += tokens
+                if waste_type:
+                    state.waste_by_type[waste_type] = (
+                        state.waste_by_type.get(waste_type, 0) + tokens
+                    )
 
         if message_total == 0:
             continue
@@ -474,11 +598,14 @@ def compute_rolling_ter(
         # Get phase-specific TER scores
         phase_ter = state.get_phase_ter_scores()
 
-        # Build waste sources breakdown
-        waste_sources = {}
+        # Build waste sources breakdown (phases + pattern types)
+        waste_sources: dict[str, int] = {}
         for phase, waste in state.phase_waste.items():
             if waste > 0:
                 waste_sources[phase] = waste
+        for wtype, wtokens in state.waste_by_type.items():
+            if wtokens > 0:
+                waste_sources[wtype] = wtokens
 
         msg_ts = _get_message_timestamp(line_data)
         signal = TERSignal(

--- a/src/ter_calculator/real_time.py
+++ b/src/ter_calculator/real_time.py
@@ -673,6 +673,7 @@ class SessionMonitor:
         poll_interval: float = DEFAULT_POLL_INTERVAL_SEC,
         model: Any | None = None,
         on_signal: Callable[[TERSignal], None] | None = None,
+        skip_history: bool = True,
     ) -> None:
         self.path = Path(path)
         self.poll_interval = poll_interval
@@ -681,6 +682,7 @@ class SessionMonitor:
         self.state = RollingTERState()
         self._stop = False
         self._file_pos = 0
+        self._caught_up = not skip_history
 
     def _read_new_lines(self) -> list[dict[str, Any]]:
         """Read lines appended since last poll using byte-offset seek."""
@@ -709,6 +711,13 @@ class SessionMonitor:
         if not new_lines:
             return []
         signals = compute_rolling_ter(self.state, new_lines, model=self.model)
+        if not self._caught_up:
+            self._caught_up = True
+            if signals:
+                last = signals[-1]
+                if self.on_signal:
+                    self.on_signal(last)
+            return signals
         if self.on_signal:
             for sig in signals:
                 self.on_signal(sig)
@@ -751,11 +760,13 @@ class LiveDashboard:
         poll_interval: float = DEFAULT_POLL_INTERVAL_SEC,
         model: Any | None = None,
         on_signal: Callable[[TERSignal], None] | None = None,
+        skip_history: bool = True,
     ) -> None:
         self.project_dir = Path(project_dir)
         self.poll_interval = poll_interval
         self.model = model
         self.on_signal = on_signal
+        self.skip_history = skip_history
         self._monitors: dict[str, SessionMonitor] = {}
         self._stop = False
 
@@ -773,6 +784,7 @@ class LiveDashboard:
                 poll_interval=self.poll_interval,
                 model=self.model,
                 on_signal=self.on_signal,
+                skip_history=self.skip_history,
             )
             self._monitors[key] = mon
             logger.info("Tracking new session: %s", path.name)

--- a/tests/features/steps/realtime_steps.py
+++ b/tests/features/steps/realtime_steps.py
@@ -681,7 +681,7 @@ def poll_once(ctx):
         path = ctx.get("session_path", ctx.get("jsonl_path"))
         interval = ctx.get("poll_interval", 2.0)
         on_signal = ctx.get("on_signal_callback")
-        ctx["monitor"] = SessionMonitor(path, poll_interval=interval, on_signal=on_signal)
+        ctx["monitor"] = SessionMonitor(path, poll_interval=interval, on_signal=on_signal, skip_history=False)
     signals = ctx["monitor"].poll_once()
     ctx["signals"] = signals
 


### PR DESCRIPTION
## Summary
- **Fix waste classification plateauing**: `_is_aligned()` had inverted reasoning logic (flagging short text instead of long rehashing) and thresholds too low for trigram-hash embeddings. Added incremental pattern detection to `RollingTERState` — duplicate tool calls, repetitive reads, bash antipatterns, repeated commands, and failed tool errors are now tracked and classified as waste in the live path. `waste_sources` in `TERSignal` now includes specific pattern types alongside phase breakdown.
- **Skip history replay**: `SessionMonitor` now silently catches up on existing file content to build accurate rolling state, then emits only a single summary signal. Subsequent polls emit signals only for genuinely new messages.
- **Resolve session directory to main JSONL**: When given a session directory (e.g. `<session-id>/`), resolves to the main session file (`<session-id>.jsonl`) in the parent directory, since the directory only contains completed agent sub-sessions.
- **Flush stdout on Windows**: Added `flush=True` to all `print()` calls in the watch output path — on Windows stdout is block-buffered when not connected to a TTY, so live signals were silently buffered.

## Test plan
- [x] All 538 existing tests pass with no regressions
- [x] Verified waste counter progresses continuously (155 increments across 847 signals vs plateauing before)
- [x] Tested against multiple live project sessions — pattern types surfaced correctly
- [x] Confirmed session directory resolves to main `.jsonl` file
- [x] Live watch confirmed working against active session

🤖 Generated with [Claude Code](https://claude.com/claude-code)