### PR TITLE
Add hooks-based real-time waste monitor

### DIFF
--- a/docs/hooks-guide.md
+++ b/docs/hooks-guide.md
@@ -1,0 +1,191 @@
+# TER Waste Monitor — Claude Code Hooks Guide
+
+The TER Waste Monitor runs as a Claude Code hook, detecting waste patterns in real-time during a session and injecting guidance back into Claude's context to course-correct before waste accumulates.
+
+## How It Works
+
+```
+Claude calls a tool (Bash, Read, Edit, etc.)
+        |
+        v
+Claude Code fires PostToolUse hook
+        |
+        v
+ter hook monitor:
+  1. Loads session state from temp file
+  2. Runs 5 fast pattern checks against the tool call
+  3. Saves updated state
+  4. Returns JSON to Claude Code
+        |
+        v
+  No alerts?  -> {} -> Claude continues normally
+  Alerts?     -> additionalContext (Claude sees guidance)
+               + systemMessage (you see a notification)
+```
+
+The monitor is stateful across tool calls within a session — it tracks read counts, edit sequences, command history, and tool call signatures in a JSON file at `{tempdir}/ter-hooks/{session_id}.json`. State is scoped per session and does not persist across sessions.
+
+## Waste Patterns Detected
+
+| Pattern | Triggers On | Default Threshold | What It Catches |
+|---------|-------------|-------------------|-----------------|
+| Bash antipattern | `Bash` tool | Immediate | `cat`, `grep`, `find`, `head`, `tail`, `rg` — commands that should use Read, Grep, or Glob |
+| Repetitive read | `Read` tool | 3 reads | Same file read 3+ times when content is likely already in context |
+| Edit fragmentation | `Edit`/`Write` | 3 consecutive | 3+ consecutive edits to the same file instead of batching |
+| Duplicate tool call | Any tool | 2 identical | Exact same tool + parameters called twice |
+| Repeated command | `Bash` tool | 3 runs | Same bash command run 3+ times (normalized to ignore `| tail -N` variants) |
+
+## Setup
+
+### Prerequisites
+
+- Python 3.11+
+- TER codebase cloned locally (pip install not required)
+
+### Option A: TER installed via pip
+
+If you've run `pip install -e .` in the TER repo:
+
+Add to your project's `.claude/settings.json`:
+
+```json
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python -c \"import json; print(json.dumps({'systemMessage': 'TER Waste Monitor active'}))\"",
+            "timeout": 5
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Bash|Read|Edit|Write|Glob|Grep",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "ter hook monitor",
+            "timeout": 15,
+            "statusMessage": "TER checking for waste..."
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+### Option B: TER not on PATH (local clone)
+
+Point `PYTHONPATH` to the TER source directory:
+
+```json
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python -c \"import json; print(json.dumps({'systemMessage': 'TER Waste Monitor active'}))\"",
+            "timeout": 5
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Bash|Read|Edit|Write|Glob|Grep",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python -m ter_calculator.cli hook monitor",
+            "timeout": 15,
+            "statusMessage": "TER checking for waste..."
+          }
+        ]
+      }
+    ]
+  },
+  "env": {
+    "PYTHONPATH": "/path/to/TER/src"
+  }
+}
+```
+
+Replace `/path/to/TER/src` with the actual path to your TER clone's `src/` directory.
+
+### Global setup
+
+To enable across all projects, add the same configuration to `~/.claude/settings.json` instead of a project-level file.
+
+## Verifying It Works
+
+When you start a new Claude Code session, you should see:
+
+```
+TER Waste Monitor active
+```
+
+This confirms the `SessionStart` hook fired. The `PostToolUse` hook then runs silently on each tool call, only surfacing notifications when waste is detected.
+
+To test manually:
+
+```bash
+echo '{"session_id":"test","tool_name":"Bash","tool_input":{"command":"cat foo.py"}}' | ter hook monitor
+```
+
+Expected output:
+
+```json
+{
+  "additionalContext": "[TER Waste Monitor]\n  Bash anti-pattern: `cat foo.py`. Use the Read tool instead of `cat`...",
+  "systemMessage": "TER: [~] bash antipattern"
+}
+```
+
+## Customizing Thresholds
+
+Add flags to the command string in your hook configuration:
+
+```json
+"command": "ter hook monitor --min-repetitive-reads 5 --min-edit-fragments 4 --min-duplicate-calls 3"
+```
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--min-repetitive-reads` | 3 | File read count before alerting |
+| `--min-edit-fragments` | 3 | Consecutive same-file edits before alerting |
+| `--min-repeated-commands` | 3 | Bash command repeat count before alerting |
+| `--min-duplicate-calls` | 2 | Identical tool call count before alerting |
+| `--no-bash-antipatterns` | off | Disable bash anti-pattern checking entirely |
+| `--state-dir` | system temp | Override state file directory |
+
+## What You See vs What Claude Sees
+
+| Output | Recipient | Purpose |
+|--------|-----------|---------|
+| `statusMessage` | You (spinner) | Shows "TER checking for waste..." while the hook runs |
+| `systemMessage` | You (warning) | Short notification like `TER: [!] repetitive read` |
+| `additionalContext` | Claude only | Detailed guidance injected into Claude's context |
+
+The `systemMessage` severity icons: `[~]` info, `[!]` warning, `[!!]` error.
+
+## Troubleshooting
+
+**No "TER Waste Monitor active" on session start:**
+- Check that `.claude/settings.json` is valid JSON (use `python -m json.tool .claude/settings.json`)
+- Verify Python is on PATH: `python --version`
+- If using Option B, verify the PYTHONPATH: `PYTHONPATH=/path/to/TER/src python -c "import ter_calculator"`
+
+**Hook fires but no alerts appear:**
+- Alerts only trigger at thresholds — a single `cat` command triggers immediately (bash antipattern), but repetitive reads require 3 occurrences
+- Check state dir for session files: `ls ${TMPDIR:-/tmp}/ter-hooks/`
+
+**Hook is slow:**
+- The monitor uses only stdlib (no numpy/ML). Typical execution is <100ms
+- If slow, check disk I/O on the state dir. Use `--state-dir` to point to a faster location

--- a/src/ter_calculator/cli.py
+++ b/src/ter_calculator/cli.py
@@ -318,6 +318,42 @@ def main(argv: list[str] | None = None) -> int:
         help="Consistency mode (default: relaxed)"
     )
 
+    # hook subcommand — Claude Code hook utilities
+    hook_parser = subparsers.add_parser(
+        "hook",
+        help="Claude Code hook utilities",
+    )
+    hook_sub = hook_parser.add_subparsers(dest="hook_command")
+
+    hook_monitor = hook_sub.add_parser(
+        "monitor",
+        help="PostToolUse hook: reads event from stdin, outputs guidance JSON",
+    )
+    hook_monitor.add_argument(
+        "--min-repetitive-reads", type=int, default=3,
+        help="File read count to trigger alert (default: 3)",
+    )
+    hook_monitor.add_argument(
+        "--min-edit-fragments", type=int, default=3,
+        help="Consecutive same-file edits to trigger alert (default: 3)",
+    )
+    hook_monitor.add_argument(
+        "--min-repeated-commands", type=int, default=3,
+        help="Repeated bash command count to trigger alert (default: 3)",
+    )
+    hook_monitor.add_argument(
+        "--min-duplicate-calls", type=int, default=2,
+        help="Duplicate tool call count to trigger alert (default: 2)",
+    )
+    hook_monitor.add_argument(
+        "--no-bash-antipatterns", action="store_true",
+        help="Disable bash anti-pattern checking",
+    )
+    hook_monitor.add_argument(
+        "--state-dir", type=str, default=None,
+        help="Override state file directory (default: system temp)",
+    )
+
     args = parser.parse_args(argv)
 
     _setup_stdout_encoding()
@@ -341,6 +377,8 @@ def main(argv: list[str] | None = None) -> int:
             return _cmd_budget(args)
         if args.command == "context":
             return _cmd_context(args)
+        if args.command == "hook":
+            return _cmd_hook(args)
     except FileNotFoundError as e:
         print(f"Error: {e}", file=sys.stderr)
         return 1
@@ -1144,6 +1182,66 @@ def _cmd_context_check(args) -> int:
 
     store.close()
     graph.close()
+    return 0
+
+
+def _cmd_hook(args) -> int:
+    """Dispatch hook sub-subcommands."""
+    hook_cmd = getattr(args, "hook_command", None)
+    if not hook_cmd:
+        print("Usage: ter hook {monitor}", file=sys.stderr)
+        return 1
+    if hook_cmd == "monitor":
+        return _cmd_hook_monitor(args)
+    print(f"Unknown hook command: {hook_cmd}", file=sys.stderr)
+    return 1
+
+
+def _cmd_hook_monitor(args) -> int:
+    """Execute the hook monitor: read stdin, process, output JSON."""
+    import json as json_mod
+
+    from .hook_monitor import (
+        HookConfig,
+        format_guidance,
+        format_notification,
+        load_state,
+        process_tool_event,
+        save_state,
+    )
+
+    try:
+        raw = sys.stdin.read()
+        event_data = json_mod.loads(raw)
+    except (json_mod.JSONDecodeError, ValueError) as e:
+        print(f"Invalid JSON on stdin: {e}", file=sys.stderr)
+        return 1
+
+    session_id = event_data.get("session_id", "unknown")
+
+    config = HookConfig(
+        min_repetitive_reads=args.min_repetitive_reads,
+        min_edit_fragments=args.min_edit_fragments,
+        min_repeated_commands=args.min_repeated_commands,
+        min_duplicate_calls=args.min_duplicate_calls,
+        enable_bash_antipatterns=not args.no_bash_antipatterns,
+        state_dir=args.state_dir,
+    )
+
+    state = load_state(session_id, config)
+    alerts, state = process_tool_event(event_data, state, config)
+    save_state(state, config)
+
+    if alerts:
+        guidance = format_guidance(alerts)
+        notification = format_notification(alerts)
+        output: dict[str, str] = {"additionalContext": guidance}
+        if notification:
+            output["systemMessage"] = notification
+        print(json_mod.dumps(output))
+    else:
+        print(json_mod.dumps({}))
+
     return 0
 
 

--- a/src/ter_calculator/hook_monitor.py
+++ b/src/ter_calculator/hook_monitor.py
@@ -1,0 +1,420 @@
+"""Claude Code PostToolUse hook monitor for real-time waste detection.
+
+Runs as a hook handler via ``ter hook monitor``.  Reads hook event JSON
+from stdin, tracks tool-usage patterns in a lightweight session state
+file, and returns ``{"additionalContext": "..."}`` guidance when waste
+patterns are detected.
+
+No heavyweight dependencies (numpy, sentence-transformers) — pure
+stdlib so the hook starts in milliseconds.
+
+Hook configuration example for ``.claude/settings.json``::
+
+    {
+      "hooks": {
+        "PostToolUse": [
+          {
+            "matcher": "Bash|Read|Edit|Write|Glob|Grep",
+            "hooks": [
+              {
+                "type": "command",
+                "command": "ter hook monitor",
+                "timeout": 15
+              }
+            ]
+          }
+        ]
+      }
+    }
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+import tempfile
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any
+
+__all__ = [
+    "HookConfig",
+    "HookSessionState",
+    "WasteAlert",
+    "check_bash_antipattern",
+    "check_duplicate_tool_call",
+    "check_edit_fragmentation",
+    "check_repeated_command",
+    "check_repetitive_read",
+    "format_guidance",
+    "format_notification",
+    "load_state",
+    "process_tool_event",
+    "save_state",
+]
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+@dataclass
+class HookConfig:
+    min_repetitive_reads: int = 3
+    min_edit_fragments: int = 3
+    min_repeated_commands: int = 3
+    min_duplicate_calls: int = 2
+    enable_bash_antipatterns: bool = True
+    state_dir: str | None = None
+
+
+# ---------------------------------------------------------------------------
+# Session state
+# ---------------------------------------------------------------------------
+
+MAX_TOOL_CALL_ENTRIES = 500
+
+@dataclass
+class HookSessionState:
+    session_id: str = ""
+    file_read_counts: dict[str, int] = field(default_factory=dict)
+    recent_edits: list[str] = field(default_factory=list)
+    bash_command_counts: dict[str, int] = field(default_factory=dict)
+    tool_call_counts: dict[str, int] = field(default_factory=dict)
+    total_events: int = 0
+
+
+# ---------------------------------------------------------------------------
+# Alerts
+# ---------------------------------------------------------------------------
+
+@dataclass
+class WasteAlert:
+    pattern_type: str
+    severity: str
+    message: str
+    details: dict[str, Any] = field(default_factory=dict)
+
+
+# ---------------------------------------------------------------------------
+# Bash anti-pattern regexes (copied from waste.py to avoid heavy imports)
+# ---------------------------------------------------------------------------
+
+_BASH_ANTIPATTERNS: list[tuple[re.Pattern[str], str, str]] = [
+    (re.compile(r"(?:^|\|\s*)cat\s+"), "Read",
+     "Use the Read tool instead of `cat` for reading files"),
+    (re.compile(r"(?:^|\|\s*)head\s+"), "Read",
+     "Use the Read tool with offset/limit instead of `head`"),
+    (re.compile(r"(?:^|\|\s*)tail\s+"), "Read",
+     "Use the Read tool with offset/limit instead of `tail`"),
+    (re.compile(r"(?:^|\|\s*)grep\s+"), "Grep",
+     "Use the Grep tool instead of `grep` for searching"),
+    (re.compile(r"(?:^|\|\s*)rg\s+"), "Grep",
+     "Use the Grep tool instead of `rg` for searching"),
+    (re.compile(r"^find\s+"), "Glob",
+     "Use the Glob tool instead of `find` for finding files"),
+]
+
+
+def _normalize_bash_command(cmd: str) -> str:
+    """Normalize a bash command for deduplication (from waste.py)."""
+    cmd = cmd.strip()
+    cmd = re.sub(r'\s*\|\s*(tail|head)\s+-\d+\s*$', '', cmd)
+    cmd = re.sub(r'\s+', ' ', cmd)
+    return cmd
+
+
+def _compute_tool_signature(tool_name: str, tool_input: dict[str, Any]) -> str:
+    """Stable hash for a tool call to detect duplicates."""
+    raw = f"{tool_name}:{json.dumps(tool_input, sort_keys=True)}"
+    return hashlib.md5(raw.encode()).hexdigest()
+
+
+# ---------------------------------------------------------------------------
+# Individual checkers
+# ---------------------------------------------------------------------------
+
+def check_bash_antipattern(
+    tool_name: str,
+    tool_input: dict[str, Any],
+) -> WasteAlert | None:
+    if tool_name != "Bash":
+        return None
+    cmd = tool_input.get("command", "").strip()
+    if not cmd:
+        return None
+    for pattern, recommended_tool, guidance in _BASH_ANTIPATTERNS:
+        if pattern.search(cmd):
+            short_cmd = cmd[:80] + "..." if len(cmd) > 80 else cmd
+            return WasteAlert(
+                pattern_type="bash_antipattern",
+                severity="info",
+                message=(
+                    f"Bash anti-pattern: `{short_cmd}`. "
+                    f"{guidance} — it is faster and avoids injecting "
+                    f"raw terminal output into context."
+                ),
+                details={"command": cmd, "recommended_tool": recommended_tool},
+            )
+    return None
+
+
+def check_repetitive_read(
+    tool_name: str,
+    tool_input: dict[str, Any],
+    state: HookSessionState,
+    threshold: int = 3,
+) -> WasteAlert | None:
+    if tool_name != "Read":
+        return None
+    file_path = tool_input.get("file_path", "")
+    if not file_path:
+        return None
+    normalized = os.path.normpath(file_path)
+    state.file_read_counts[normalized] = state.file_read_counts.get(normalized, 0) + 1
+    count = state.file_read_counts[normalized]
+    if count >= threshold:
+        short_path = os.path.basename(normalized)
+        return WasteAlert(
+            pattern_type="repetitive_read",
+            severity="warning" if count >= threshold + 2 else "info",
+            message=(
+                f"File '{short_path}' has been read {count} times this session. "
+                f"Its content is likely already in your context — avoid re-reading "
+                f"files unless they have been modified since your last read."
+            ),
+            details={"file_path": normalized, "read_count": count},
+        )
+    return None
+
+
+def check_edit_fragmentation(
+    tool_name: str,
+    tool_input: dict[str, Any],
+    state: HookSessionState,
+    threshold: int = 3,
+) -> WasteAlert | None:
+    if tool_name not in ("Edit", "Write"):
+        state.recent_edits.clear()
+        return None
+
+    file_path = tool_input.get("file_path", "")
+    if not file_path:
+        return None
+    normalized = os.path.normpath(file_path)
+
+    state.recent_edits.append(normalized)
+    if len(state.recent_edits) > 20:
+        state.recent_edits = state.recent_edits[-20:]
+
+    consecutive = 0
+    for path in reversed(state.recent_edits):
+        if path == normalized:
+            consecutive += 1
+        else:
+            break
+
+    if consecutive >= threshold:
+        short_path = os.path.basename(normalized)
+        return WasteAlert(
+            pattern_type="edit_fragmentation",
+            severity="warning",
+            message=(
+                f"{consecutive} consecutive edits to '{short_path}'. "
+                f"Try to batch multiple changes into fewer Edit calls "
+                f"to reduce round-trips and context churn."
+            ),
+            details={"file_path": normalized, "consecutive_edits": consecutive},
+        )
+    return None
+
+
+def check_duplicate_tool_call(
+    tool_name: str,
+    tool_input: dict[str, Any],
+    state: HookSessionState,
+    threshold: int = 2,
+) -> WasteAlert | None:
+    sig = _compute_tool_signature(tool_name, tool_input)
+    state.tool_call_counts[sig] = state.tool_call_counts.get(sig, 0) + 1
+
+    if len(state.tool_call_counts) > MAX_TOOL_CALL_ENTRIES:
+        sorted_sigs = sorted(state.tool_call_counts, key=state.tool_call_counts.get)  # type: ignore[arg-type]
+        for s in sorted_sigs[:100]:
+            del state.tool_call_counts[s]
+
+    count = state.tool_call_counts[sig]
+    if count >= threshold:
+        return WasteAlert(
+            pattern_type="duplicate_tool_call",
+            severity="warning",
+            message=(
+                f"Duplicate {tool_name} call (identical parameters, "
+                f"invocation #{count}). The result is already in your "
+                f"context from a previous call."
+            ),
+            details={
+                "tool_name": tool_name,
+                "invocation_count": count,
+                "signature": sig,
+            },
+        )
+    return None
+
+
+def check_repeated_command(
+    tool_name: str,
+    tool_input: dict[str, Any],
+    state: HookSessionState,
+    threshold: int = 3,
+) -> WasteAlert | None:
+    if tool_name != "Bash":
+        return None
+    cmd = tool_input.get("command", "")
+    if not cmd:
+        return None
+    normalized = _normalize_bash_command(cmd)
+    if not normalized:
+        return None
+    state.bash_command_counts[normalized] = (
+        state.bash_command_counts.get(normalized, 0) + 1
+    )
+    count = state.bash_command_counts[normalized]
+    if count >= threshold:
+        short_cmd = normalized[:60] + "..." if len(normalized) > 60 else normalized
+        return WasteAlert(
+            pattern_type="repeated_command",
+            severity="warning",
+            message=(
+                f"Command `{short_cmd}` has been run {count} times. "
+                f"If re-running to verify a fix, consider whether the "
+                f"approach needs to change rather than retrying."
+            ),
+            details={"command": normalized, "run_count": count},
+        )
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Orchestration
+# ---------------------------------------------------------------------------
+
+def process_tool_event(
+    event_data: dict[str, Any],
+    state: HookSessionState,
+    config: HookConfig | None = None,
+) -> tuple[list[WasteAlert], HookSessionState]:
+    cfg = config or HookConfig()
+
+    tool_name = event_data.get("tool_name", "")
+    tool_input = event_data.get("tool_input", {})
+    if not isinstance(tool_input, dict):
+        tool_input = {}
+
+    state.total_events += 1
+    alerts: list[WasteAlert] = []
+
+    if cfg.enable_bash_antipatterns:
+        alert = check_bash_antipattern(tool_name, tool_input)
+        if alert:
+            alerts.append(alert)
+
+    alert = check_repetitive_read(
+        tool_name, tool_input, state, cfg.min_repetitive_reads,
+    )
+    if alert:
+        alerts.append(alert)
+
+    alert = check_edit_fragmentation(
+        tool_name, tool_input, state, cfg.min_edit_fragments,
+    )
+    if alert:
+        alerts.append(alert)
+
+    alert = check_duplicate_tool_call(
+        tool_name, tool_input, state, cfg.min_duplicate_calls,
+    )
+    if alert:
+        alerts.append(alert)
+
+    alert = check_repeated_command(
+        tool_name, tool_input, state, cfg.min_repeated_commands,
+    )
+    if alert:
+        alerts.append(alert)
+
+    return alerts, state
+
+
+# ---------------------------------------------------------------------------
+# Guidance formatting
+# ---------------------------------------------------------------------------
+
+def format_guidance(alerts: list[WasteAlert]) -> str:
+    if not alerts:
+        return ""
+    lines = ["[TER Waste Monitor]"]
+    for i, alert in enumerate(alerts, 1):
+        prefix = f"  {i}. " if len(alerts) > 1 else "  "
+        lines.append(f"{prefix}{alert.message}")
+    return "\n".join(lines)
+
+
+_SEVERITY_ICON = {"info": "~", "warning": "!", "error": "!!"}
+
+
+def format_notification(alerts: list[WasteAlert]) -> str:
+    if not alerts:
+        return ""
+    parts: list[str] = []
+    for alert in alerts:
+        icon = _SEVERITY_ICON.get(alert.severity, "~")
+        short = alert.pattern_type.replace("_", " ")
+        parts.append(f"[{icon}] {short}")
+    return f"TER: {', '.join(parts)}"
+
+
+# ---------------------------------------------------------------------------
+# State persistence
+# ---------------------------------------------------------------------------
+
+def _get_state_dir(config: HookConfig | None = None) -> Path:
+    if config and config.state_dir:
+        return Path(config.state_dir)
+    return Path(tempfile.gettempdir()) / "ter-hooks"
+
+
+def load_state(
+    session_id: str,
+    config: HookConfig | None = None,
+) -> HookSessionState:
+    state_dir = _get_state_dir(config)
+    state_file = state_dir / f"{session_id}.json"
+    if state_file.exists():
+        try:
+            data = json.loads(state_file.read_text(encoding="utf-8"))
+            return HookSessionState(**data)
+        except (json.JSONDecodeError, TypeError):
+            pass
+    return HookSessionState(session_id=session_id)
+
+
+def save_state(
+    state: HookSessionState,
+    config: HookConfig | None = None,
+) -> None:
+    state_dir = _get_state_dir(config)
+    state_dir.mkdir(parents=True, exist_ok=True)
+    state_file = state_dir / f"{state.session_id}.json"
+    tmp_fd, tmp_path = tempfile.mkstemp(dir=str(state_dir), suffix=".tmp")
+    try:
+        with os.fdopen(tmp_fd, "w", encoding="utf-8") as f:
+            json.dump(asdict(state), f)
+        os.replace(tmp_path, str(state_file))
+    except BaseException:
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        raise

--- a/tests/unit/test_hook_monitor.py
+++ b/tests/unit/test_hook_monitor.py
@@ -1,0 +1,516 @@
+"""Tests for the Claude Code hook waste monitor."""
+
+from __future__ import annotations
+
+import json
+import os
+
+from ter_calculator.hook_monitor import (
+    HookConfig,
+    HookSessionState,
+    WasteAlert,
+    check_bash_antipattern,
+    check_duplicate_tool_call,
+    check_edit_fragmentation,
+    check_repeated_command,
+    check_repetitive_read,
+    format_guidance,
+    format_notification,
+    load_state,
+    process_tool_event,
+    save_state,
+)
+
+
+# -----------------------------------------------------------------------
+# check_bash_antipattern
+# -----------------------------------------------------------------------
+
+class TestCheckBashAntipattern:
+    def test_detects_cat(self):
+        alert = check_bash_antipattern("Bash", {"command": "cat foo.py"})
+        assert alert is not None
+        assert alert.pattern_type == "bash_antipattern"
+        assert "Read" in alert.message
+
+    def test_detects_grep(self):
+        alert = check_bash_antipattern("Bash", {"command": "grep pattern src/"})
+        assert alert is not None
+        assert "Grep" in alert.message
+
+    def test_detects_find(self):
+        alert = check_bash_antipattern("Bash", {"command": "find . -name '*.py'"})
+        assert alert is not None
+        assert "Glob" in alert.message
+
+    def test_detects_rg(self):
+        alert = check_bash_antipattern("Bash", {"command": "rg TODO"})
+        assert alert is not None
+        assert "Grep" in alert.message
+
+    def test_detects_piped_grep(self):
+        alert = check_bash_antipattern("Bash", {"command": "git log | grep error"})
+        assert alert is not None
+        assert "Grep" in alert.message
+
+    def test_detects_head(self):
+        alert = check_bash_antipattern("Bash", {"command": "head -20 src/models.py"})
+        assert alert is not None
+        assert "Read" in alert.message
+
+    def test_detects_tail(self):
+        alert = check_bash_antipattern("Bash", {"command": "tail -50 output.log"})
+        assert alert is not None
+        assert "Read" in alert.message
+
+    def test_ignores_safe_commands(self):
+        assert check_bash_antipattern("Bash", {"command": "git status"}) is None
+        assert check_bash_antipattern("Bash", {"command": "pytest tests/"}) is None
+        assert check_bash_antipattern("Bash", {"command": "npm install"}) is None
+
+    def test_ignores_non_bash(self):
+        assert check_bash_antipattern("Read", {"file_path": "foo.py"}) is None
+        assert check_bash_antipattern("Edit", {"file_path": "foo.py"}) is None
+
+    def test_ignores_empty_command(self):
+        assert check_bash_antipattern("Bash", {"command": ""}) is None
+        assert check_bash_antipattern("Bash", {}) is None
+
+    def test_truncates_long_commands(self):
+        long_cmd = "cat " + "x" * 200
+        alert = check_bash_antipattern("Bash", {"command": long_cmd})
+        assert alert is not None
+        assert "..." in alert.message
+
+    def test_details_contain_recommended_tool(self):
+        alert = check_bash_antipattern("Bash", {"command": "cat foo.py"})
+        assert alert is not None
+        assert alert.details["recommended_tool"] == "Read"
+
+
+# -----------------------------------------------------------------------
+# check_repetitive_read
+# -----------------------------------------------------------------------
+
+class TestCheckRepetitiveRead:
+    def test_no_alert_below_threshold(self):
+        state = HookSessionState(session_id="s1")
+        assert check_repetitive_read("Read", {"file_path": "a.py"}, state) is None
+        assert check_repetitive_read("Read", {"file_path": "a.py"}, state) is None
+
+    def test_alerts_at_threshold(self):
+        state = HookSessionState(session_id="s1")
+        check_repetitive_read("Read", {"file_path": "a.py"}, state)
+        check_repetitive_read("Read", {"file_path": "a.py"}, state)
+        alert = check_repetitive_read("Read", {"file_path": "a.py"}, state)
+        assert alert is not None
+        assert alert.pattern_type == "repetitive_read"
+        assert "3 times" in alert.message
+
+    def test_different_files_independent(self):
+        state = HookSessionState(session_id="s1")
+        check_repetitive_read("Read", {"file_path": "a.py"}, state)
+        check_repetitive_read("Read", {"file_path": "b.py"}, state)
+        check_repetitive_read("Read", {"file_path": "c.py"}, state)
+        assert state.file_read_counts.get(os.path.normpath("a.py")) == 1
+
+    def test_state_updated(self):
+        state = HookSessionState(session_id="s1")
+        check_repetitive_read("Read", {"file_path": "a.py"}, state)
+        normalized = os.path.normpath("a.py")
+        assert state.file_read_counts[normalized] == 1
+
+    def test_ignores_non_read(self):
+        state = HookSessionState(session_id="s1")
+        assert check_repetitive_read("Bash", {"command": "ls"}, state) is None
+
+    def test_ignores_empty_path(self):
+        state = HookSessionState(session_id="s1")
+        assert check_repetitive_read("Read", {"file_path": ""}, state) is None
+        assert check_repetitive_read("Read", {}, state) is None
+
+    def test_custom_threshold(self):
+        state = HookSessionState(session_id="s1")
+        check_repetitive_read("Read", {"file_path": "a.py"}, state, threshold=2)
+        alert = check_repetitive_read("Read", {"file_path": "a.py"}, state, threshold=2)
+        assert alert is not None
+
+    def test_severity_escalates(self):
+        state = HookSessionState(session_id="s1")
+        for _ in range(4):
+            check_repetitive_read("Read", {"file_path": "a.py"}, state)
+        alert = check_repetitive_read("Read", {"file_path": "a.py"}, state)
+        assert alert is not None
+        assert alert.severity == "warning"
+
+
+# -----------------------------------------------------------------------
+# check_edit_fragmentation
+# -----------------------------------------------------------------------
+
+class TestCheckEditFragmentation:
+    def test_no_alert_for_single_edit(self):
+        state = HookSessionState(session_id="s1")
+        assert check_edit_fragmentation("Edit", {"file_path": "a.py"}, state) is None
+
+    def test_alerts_on_three_consecutive(self):
+        state = HookSessionState(session_id="s1")
+        check_edit_fragmentation("Edit", {"file_path": "a.py"}, state)
+        check_edit_fragmentation("Edit", {"file_path": "a.py"}, state)
+        alert = check_edit_fragmentation("Edit", {"file_path": "a.py"}, state)
+        assert alert is not None
+        assert alert.pattern_type == "edit_fragmentation"
+        assert "3 consecutive" in alert.message
+
+    def test_broken_by_different_file(self):
+        state = HookSessionState(session_id="s1")
+        check_edit_fragmentation("Edit", {"file_path": "a.py"}, state)
+        check_edit_fragmentation("Edit", {"file_path": "a.py"}, state)
+        check_edit_fragmentation("Edit", {"file_path": "b.py"}, state)
+        alert = check_edit_fragmentation("Edit", {"file_path": "a.py"}, state)
+        assert alert is None
+
+    def test_broken_by_non_edit_tool(self):
+        state = HookSessionState(session_id="s1")
+        check_edit_fragmentation("Edit", {"file_path": "a.py"}, state)
+        check_edit_fragmentation("Edit", {"file_path": "a.py"}, state)
+        check_edit_fragmentation("Read", {"file_path": "a.py"}, state)
+        alert = check_edit_fragmentation("Edit", {"file_path": "a.py"}, state)
+        assert alert is None
+
+    def test_write_counts_as_edit(self):
+        state = HookSessionState(session_id="s1")
+        check_edit_fragmentation("Edit", {"file_path": "a.py"}, state)
+        check_edit_fragmentation("Write", {"file_path": "a.py"}, state)
+        alert = check_edit_fragmentation("Edit", {"file_path": "a.py"}, state)
+        assert alert is not None
+
+    def test_recent_edits_capped(self):
+        state = HookSessionState(session_id="s1")
+        for i in range(25):
+            check_edit_fragmentation("Edit", {"file_path": f"f{i}.py"}, state)
+        assert len(state.recent_edits) <= 20
+
+
+# -----------------------------------------------------------------------
+# check_duplicate_tool_call
+# -----------------------------------------------------------------------
+
+class TestCheckDuplicateToolCall:
+    def test_no_alert_on_first_call(self):
+        state = HookSessionState(session_id="s1")
+        alert = check_duplicate_tool_call("Read", {"file_path": "a.py"}, state)
+        assert alert is None
+
+    def test_alerts_on_second_identical_call(self):
+        state = HookSessionState(session_id="s1")
+        check_duplicate_tool_call("Read", {"file_path": "a.py"}, state)
+        alert = check_duplicate_tool_call("Read", {"file_path": "a.py"}, state)
+        assert alert is not None
+        assert alert.pattern_type == "duplicate_tool_call"
+        assert "invocation #2" in alert.message
+
+    def test_different_inputs_not_duplicate(self):
+        state = HookSessionState(session_id="s1")
+        check_duplicate_tool_call("Read", {"file_path": "a.py"}, state)
+        alert = check_duplicate_tool_call("Read", {"file_path": "b.py"}, state)
+        assert alert is None
+
+    def test_different_tools_not_duplicate(self):
+        state = HookSessionState(session_id="s1")
+        check_duplicate_tool_call("Read", {"file_path": "a.py"}, state)
+        alert = check_duplicate_tool_call("Edit", {"file_path": "a.py"}, state)
+        assert alert is None
+
+    def test_higher_threshold(self):
+        state = HookSessionState(session_id="s1")
+        check_duplicate_tool_call("Read", {"file_path": "a.py"}, state, threshold=3)
+        alert = check_duplicate_tool_call("Read", {"file_path": "a.py"}, state, threshold=3)
+        assert alert is None
+        alert = check_duplicate_tool_call("Read", {"file_path": "a.py"}, state, threshold=3)
+        assert alert is not None
+
+    def test_tool_call_counts_capped(self):
+        state = HookSessionState(session_id="s1")
+        for i in range(600):
+            check_duplicate_tool_call("Bash", {"command": f"cmd{i}"}, state)
+        assert len(state.tool_call_counts) <= 510
+
+
+# -----------------------------------------------------------------------
+# check_repeated_command
+# -----------------------------------------------------------------------
+
+class TestCheckRepeatedCommand:
+    def test_alerts_at_threshold(self):
+        state = HookSessionState(session_id="s1")
+        check_repeated_command("Bash", {"command": "pytest tests/"}, state)
+        check_repeated_command("Bash", {"command": "pytest tests/"}, state)
+        alert = check_repeated_command("Bash", {"command": "pytest tests/"}, state)
+        assert alert is not None
+        assert alert.pattern_type == "repeated_command"
+        assert "3 times" in alert.message
+
+    def test_no_alert_below_threshold(self):
+        state = HookSessionState(session_id="s1")
+        check_repeated_command("Bash", {"command": "pytest tests/"}, state)
+        alert = check_repeated_command("Bash", {"command": "pytest tests/"}, state)
+        assert alert is None
+
+    def test_normalizes_tail_variants(self):
+        state = HookSessionState(session_id="s1")
+        check_repeated_command("Bash", {"command": "git log | tail -30"}, state)
+        check_repeated_command("Bash", {"command": "git log | tail -50"}, state)
+        alert = check_repeated_command("Bash", {"command": "git log | tail -10"}, state)
+        assert alert is not None
+
+    def test_different_commands_independent(self):
+        state = HookSessionState(session_id="s1")
+        check_repeated_command("Bash", {"command": "pytest tests/"}, state)
+        check_repeated_command("Bash", {"command": "ruff check src/"}, state)
+        check_repeated_command("Bash", {"command": "git status"}, state)
+        for key in state.bash_command_counts.values():
+            assert key == 1
+
+    def test_ignores_non_bash(self):
+        state = HookSessionState(session_id="s1")
+        assert check_repeated_command("Read", {"file_path": "a.py"}, state) is None
+
+    def test_ignores_empty_command(self):
+        state = HookSessionState(session_id="s1")
+        assert check_repeated_command("Bash", {"command": ""}, state) is None
+        assert check_repeated_command("Bash", {}, state) is None
+
+    def test_truncates_long_commands(self):
+        state = HookSessionState(session_id="s1")
+        long_cmd = "echo " + "x" * 200
+        for _ in range(3):
+            check_repeated_command("Bash", {"command": long_cmd}, state)
+        alert = check_repeated_command("Bash", {"command": long_cmd}, state)
+        assert alert is not None
+        assert "..." in alert.message
+
+
+# -----------------------------------------------------------------------
+# process_tool_event
+# -----------------------------------------------------------------------
+
+class TestProcessToolEvent:
+    def test_bash_antipattern_detected(self):
+        state = HookSessionState(session_id="s1")
+        event = {"tool_name": "Bash", "tool_input": {"command": "cat foo.py"}}
+        alerts, state = process_tool_event(event, state)
+        assert len(alerts) >= 1
+        assert any(a.pattern_type == "bash_antipattern" for a in alerts)
+
+    def test_multiple_alerts_returned(self):
+        state = HookSessionState(session_id="s1")
+        # Prime repeated command state
+        for _ in range(2):
+            process_tool_event(
+                {"tool_name": "Bash", "tool_input": {"command": "cat foo.py"}},
+                state,
+            )
+        # Third call: bash_antipattern + repeated_command + duplicate_tool_call
+        alerts, state = process_tool_event(
+            {"tool_name": "Bash", "tool_input": {"command": "cat foo.py"}},
+            state,
+        )
+        types = {a.pattern_type for a in alerts}
+        assert "bash_antipattern" in types
+        assert "repeated_command" in types
+
+    def test_state_updated_across_calls(self):
+        state = HookSessionState(session_id="s1")
+        process_tool_event(
+            {"tool_name": "Read", "tool_input": {"file_path": "a.py"}},
+            state,
+        )
+        assert state.total_events == 1
+        normalized = os.path.normpath("a.py")
+        assert state.file_read_counts[normalized] == 1
+
+    def test_unknown_tool_no_crash(self):
+        state = HookSessionState(session_id="s1")
+        alerts, state = process_tool_event(
+            {"tool_name": "UnknownTool", "tool_input": {"x": 1}},
+            state,
+        )
+        assert alerts == []
+        assert state.total_events == 1
+
+    def test_non_dict_tool_input(self):
+        state = HookSessionState(session_id="s1")
+        alerts, state = process_tool_event(
+            {"tool_name": "Bash", "tool_input": "not a dict"},
+            state,
+        )
+        assert isinstance(alerts, list)
+
+    def test_missing_fields(self):
+        state = HookSessionState(session_id="s1")
+        alerts, state = process_tool_event({}, state)
+        assert alerts == []
+
+    def test_config_disables_bash_antipatterns(self):
+        state = HookSessionState(session_id="s1")
+        config = HookConfig(enable_bash_antipatterns=False)
+        alerts, state = process_tool_event(
+            {"tool_name": "Bash", "tool_input": {"command": "cat foo.py"}},
+            state,
+            config,
+        )
+        assert not any(a.pattern_type == "bash_antipattern" for a in alerts)
+
+
+# -----------------------------------------------------------------------
+# State persistence
+# -----------------------------------------------------------------------
+
+class TestStatePersistence:
+    def test_save_and_load_roundtrip(self, tmp_path):
+        config = HookConfig(state_dir=str(tmp_path))
+        state = HookSessionState(
+            session_id="test-session",
+            file_read_counts={"a.py": 3, "b.py": 1},
+            bash_command_counts={"pytest": 2},
+            total_events=5,
+        )
+        save_state(state, config)
+        loaded = load_state("test-session", config)
+        assert loaded.session_id == "test-session"
+        assert loaded.file_read_counts == {"a.py": 3, "b.py": 1}
+        assert loaded.bash_command_counts == {"pytest": 2}
+        assert loaded.total_events == 5
+
+    def test_load_missing_creates_fresh(self, tmp_path):
+        config = HookConfig(state_dir=str(tmp_path))
+        state = load_state("nonexistent", config)
+        assert state.session_id == "nonexistent"
+        assert state.total_events == 0
+        assert state.file_read_counts == {}
+
+    def test_state_dir_created(self, tmp_path):
+        subdir = tmp_path / "nested" / "dir"
+        config = HookConfig(state_dir=str(subdir))
+        state = HookSessionState(session_id="s1")
+        save_state(state, config)
+        assert subdir.exists()
+
+    def test_corrupt_state_file_handled(self, tmp_path):
+        config = HookConfig(state_dir=str(tmp_path))
+        state_file = tmp_path / "corrupt.json"
+        state_file.write_text("not valid json", encoding="utf-8")
+        state = load_state("corrupt", config)
+        assert state.session_id == "corrupt"
+        assert state.total_events == 0
+
+
+# -----------------------------------------------------------------------
+# format_guidance
+# -----------------------------------------------------------------------
+
+class TestFormatGuidance:
+    def test_single_alert(self):
+        alerts = [WasteAlert("bash_antipattern", "info", "Use Read instead")]
+        result = format_guidance(alerts)
+        assert "[TER Waste Monitor]" in result
+        assert "Use Read instead" in result
+
+    def test_multiple_alerts(self):
+        alerts = [
+            WasteAlert("bash_antipattern", "info", "Alert one"),
+            WasteAlert("repetitive_read", "warning", "Alert two"),
+        ]
+        result = format_guidance(alerts)
+        assert "1." in result
+        assert "2." in result
+        assert "Alert one" in result
+        assert "Alert two" in result
+
+    def test_empty_alerts(self):
+        assert format_guidance([]) == ""
+
+
+# -----------------------------------------------------------------------
+# format_notification
+# -----------------------------------------------------------------------
+
+class TestFormatNotification:
+    def test_single_info_alert(self):
+        alerts = [WasteAlert("bash_antipattern", "info", "msg")]
+        result = format_notification(alerts)
+        assert "TER:" in result
+        assert "bash antipattern" in result
+        assert "[~]" in result
+
+    def test_single_warning_alert(self):
+        alerts = [WasteAlert("repetitive_read", "warning", "msg")]
+        result = format_notification(alerts)
+        assert "[!]" in result
+
+    def test_multiple_alerts(self):
+        alerts = [
+            WasteAlert("bash_antipattern", "info", "msg1"),
+            WasteAlert("repetitive_read", "warning", "msg2"),
+        ]
+        result = format_notification(alerts)
+        assert "bash antipattern" in result
+        assert "repetitive read" in result
+
+    def test_empty_alerts(self):
+        assert format_notification([]) == ""
+
+
+# -----------------------------------------------------------------------
+# CLI integration (ter hook monitor)
+# -----------------------------------------------------------------------
+
+class TestHookMonitorCLI:
+    def test_monitor_bash_antipattern(self, monkeypatch, capsys, tmp_path):
+        import io
+        from ter_calculator.cli import main
+
+        event = json.dumps({
+            "session_id": "test-cli",
+            "tool_name": "Bash",
+            "tool_input": {"command": "cat foo.py"},
+        })
+        monkeypatch.setattr("sys.stdin", io.StringIO(event))
+        result = main(["hook", "monitor", "--state-dir", str(tmp_path)])
+        assert result == 0
+        output = json.loads(capsys.readouterr().out)
+        assert "additionalContext" in output
+        assert "Read" in output["additionalContext"]
+        assert "systemMessage" in output
+        assert "TER:" in output["systemMessage"]
+
+    def test_monitor_no_alerts(self, monkeypatch, capsys, tmp_path):
+        import io
+        from ter_calculator.cli import main
+
+        event = json.dumps({
+            "session_id": "test-cli",
+            "tool_name": "Bash",
+            "tool_input": {"command": "git status"},
+        })
+        monkeypatch.setattr("sys.stdin", io.StringIO(event))
+        result = main(["hook", "monitor", "--state-dir", str(tmp_path)])
+        assert result == 0
+        output = json.loads(capsys.readouterr().out)
+        assert output == {}
+
+    def test_monitor_invalid_stdin(self, monkeypatch, capsys):
+        import io
+        from ter_calculator.cli import main
+
+        monkeypatch.setattr("sys.stdin", io.StringIO("not json"))
+        result = main(["hook", "monitor"])
+        assert result == 1
+
+    def test_hook_no_subcommand(self, capsys):
+        from ter_calculator.cli import main
+
+        result = main(["hook"])
+        assert result == 1
+        assert "Usage" in capsys.readouterr().err


### PR DESCRIPTION
## Summary

- Adds `ter hook monitor` CLI subcommand that acts as a Claude Code `PostToolUse` hook handler
- Detects 5 waste patterns in real-time (bash antipatterns, repetitive reads, edit fragmentation, duplicate tool calls, repeated commands) using pure stdlib — no embeddings, starts in milliseconds
- Returns `additionalContext` (guidance for Claude) and `systemMessage` (notification for the user) when waste is detected
- Includes `SessionStart` hook example so users see "TER Waste Monitor active" on launch
- 61 unit tests, all passing

## How to use

Add to any project's `.claude/settings.json`:
```json
{
  "hooks": {
    "SessionStart": [{"hooks": [{"type": "command", "command": "python -c \"import json; print(json.dumps({'systemMessage': 'TER Waste Monitor active'}))\"", "timeout": 5}]}],
    "PostToolUse": [{"matcher": "Bash|Read|Edit|Write|Glob|Grep", "hooks": [{"type": "command", "command": "ter hook monitor", "timeout": 15, "statusMessage": "TER checking for waste..."}]}]
  }
}
```

See `docs/hooks-guide.md` for full setup, threshold tuning, and troubleshooting.

## Test plan

- [x] `pytest tests/unit/test_hook_monitor.py` — 61 tests passing
- [x] `ruff check` — clean
- [x] Manual end-to-end: pipe hook JSON through `ter hook monitor`, verify output
- [x] Tested in live Claude Code session on separate project (eveomni) — SessionStart message confirmed visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)